### PR TITLE
Specify minimum cmake version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - {{ compiler('cxx') }}
     - autoconf  # [unix]
     - make      # [unix]
-    - cmake     # [win]
+    - cmake >=3.12  # [win]
   host:
     - python
     - openssl
@@ -42,7 +42,7 @@ outputs:
         - {{ compiler('cxx') }}
         - autoconf  # [unix]
         - make      # [unix]
-        - cmake     # [win]
+        - cmake >=3.12  # [win]
       host:
         - openssl
         - zlib
@@ -74,7 +74,7 @@ outputs:
         - {{ compiler('cxx') }}
         - autoconf  # [unix]
         - make      # [unix]
-        - cmake     # [win]
+        - cmake >=3.12  # [win]
       host:
         - python
         - openssl


### PR DESCRIPTION
Local conda-build using this recipe fails due to wrong cmake version installed.

See:
https://github.com/conda-forge/omniorb-feedstock/blob/e6fdaac934c356bf390ed9025bf9c8ad3f759e7d/recipe/omniorb-4.2.4-cmake.patch#L38