### PR TITLE
Clean include files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - omniorb-4.2.5-cmake.patch  # [win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -47,8 +47,15 @@ outputs:
         - openssl
         - zlib
     files:
-      - include                      # [unix]
-      - Library/include              # [win]
+      - include/COS                  # [unix]
+      - include/omniORB4             # [unix]
+      - include/omnithread           # [unix]
+      - include/omni*                # [unix]
+      - Library/include/COS          # [win]
+      - Library/include/omniORB4     # [win]
+      - Library/include/omnithread   # [win]
+      - Library/include/omniVms      # [win]
+      - Library/include/omni*        # [win]
       - lib/libomni*.so*             # [linux]
       - lib/libCOS*.so*              # [linux]
       - lib/libomni*.dylib           # [osx]


### PR DESCRIPTION

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

I noticed some warnings when compiling TangoTest:

ClobberWarning: Conda was asked to clobber an existing path.
  source path: C:\Users\xxxxx\mambaforge\pkgs\omniorb-libs-4.2.5-hc7e8586_1\Library\include\openssl\ui.h
  target path: C:\Users\xxxxx\mambaforge\conda-bld\tango-test_1648068062307\_test_env\Library\include\openssl\ui.h

The omniorb-libs output includes files from other libs under "include".
By default conda-build only includes new files when creating a package but that doesn't seem to work
when using several outputs.
