### PR TITLE
Fix osx-arm64 compilation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,11 @@ source:
     - patch-configure.diff
     - 0001-Avoid-kernel-128-character-shebang-limit.patch
     - 0002-Update-config-guess.patch
-    - omniorb-4.2.5-cmake.patch  # [win]
+    - omniorb-4.2.5-cmake.patch    # [win]
+    - omniorb-cross-compile.patch  # [build_platform != target_platform]
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:

--- a/recipe/omniorb-cross-compile.patch
+++ b/recipe/omniorb-cross-compile.patch
@@ -1,0 +1,14 @@
+diff --git a/src/dir.mk b/src/dir.mk
+index 7d1d4f2..f22d04a 100644
+--- a/src/dir.mk
++++ b/src/dir.mk
+@@ -12,9 +12,7 @@ endif
+ 
+ SUBDIRS += lib
+ 
+-ifndef EmbeddedSystem
+ SUBDIRS += appl services
+-endif
+ 
+ all::
+ 	@echo


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

Some files, like COS libraries, were missing in the osx-arm64 package.

Add patch to force appl and services compilation.
In 4.2.x, cross-compiling is activated with make variables calling it an "EmbeddedSystem", with the expectation that it is a minimal small system, and therefore it does not build things like omniNames or the COS libraries.

See https://www.omniorb-support.com/pipermail/omniorb-list/2022-October/032229.html