### PR TITLE
Apply patches from svn to fix aarch64 bug

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 openssl:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 openssl:

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 openssl:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 openssl:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 openssl:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 openssl:

--- a/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 openssl:

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 openssl:

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 openssl:

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 openssl:

--- a/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 openssl:

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 openssl:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,14 +8,18 @@ source:
   url: https://sourceforge.net/projects/omniorb/files/omniORB/omniORB-{{ version }}/omniORB-{{ version }}.tar.bz2
   sha256: f05cf999fb2f4c24c1173b3c44ad97215591d0d1a48d49ac0843c464efe073bb
   patches:
-    - patch-configure.diff                                 # [unix]
     - 0001-Avoid-kernel-128-character-shebang-limit.patch  # [unix]
     - 0002-Update-config-guess.patch                       # [unix]
     - windows-build.patch                                  # [win]
     - omniorb-cross-compile.patch  # [build_platform != target_platform]
+    - omniorb-r6639.patch                                  # [unix]
+    - omniorb-r6648.patch                                  # [unix]
+    - omniorb-r6651.patch                                  # [unix]
+    - omniorb-r6653.patch                                  # [unix]
+    - patch-configure.diff                                 # [unix]
 
 build:
-  number: 6
+  number: 7
 
 requirements:
   build:

--- a/recipe/omniorb-r6639.patch
+++ b/recipe/omniorb-r6639.patch
@@ -1,0 +1,13 @@
+Index: omniORB/include/omniORB4/CORBA_sysdep.h
+===================================================================
+--- omniORB/include/omniORB4/CORBA_sysdep.h	(revision 6638)
++++ omniORB/include/omniORB4/CORBA_sysdep.h	(revision 6639)
+@@ -89,7 +89,7 @@
+ // __VFP_FP__ means that the floating point format in use is that of the ARM 
+ // VFP unit, which is native-endian IEEE-754.
+ #if defined(__arm__)
+-#  if defined(__armv5teb__) || defined(__VFP_FP__)
++#  if defined(__armv5teb__) || defined(__VFP_FP__) || defined(__aarch64__)
+ #    define NO_OMNI_MIXED_ENDIAN_DOUBLE
+ #  else
+ #    define OMNI_MIXED_ENDIAN_DOUBLE

--- a/recipe/omniorb-r6648.patch
+++ b/recipe/omniorb-r6648.patch
@@ -1,0 +1,10466 @@
+Index: omniORB/acinclude.m4
+===================================================================
+--- omniORB/acinclude.m4	(revision 6647)
++++ omniORB/acinclude.m4	(revision 6648)
+@@ -6,8 +6,7 @@
+ [AC_CACHE_CHECK(for OpenSSL root,
+ omni_cv_openssl_root,
+ [AC_ARG_WITH(openssl,
+-             AC_HELP_STRING([--with-openssl],
+-               [OpenSSL root directory (default none)]),
++             AS_HELP_STRING([--with-openssl],[OpenSSL root directory (default none)]),
+              omni_cv_openssl_root=$withval,
+              omni_cv_openssl_root=no)
+ ])
+@@ -110,7 +109,7 @@
+ omni_cv_cxx_catch_by_base,
+ [AC_REQUIRE([AC_CXX_EXCEPTIONS])
+  AC_LANG_PUSH(C++)
+- AC_TRY_RUN([
++ AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ class A {
+ public:
+   A() {}
+@@ -131,9 +130,7 @@
+   }
+   return 2;
+ }
+-],
+- omni_cv_cxx_catch_by_base=yes, omni_cv_cxx_catch_by_base=no,
+- omni_cv_cxx_catch_by_base=yes)
++]])],[omni_cv_cxx_catch_by_base=yes],[omni_cv_cxx_catch_by_base=no],[omni_cv_cxx_catch_by_base=yes])
+  AC_LANG_POP(C++)
+ ])
+ if test "$omni_cv_cxx_catch_by_base" = yes; then
+@@ -146,7 +143,7 @@
+ [AC_CACHE_CHECK(whether base constructors have to be fully-qualified,
+ omni_cv_cxx_need_fq_base_ctor,
+ [AC_LANG_PUSH(C++)
+- AC_TRY_COMPILE([
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ /* Test sub-classes */
+ class A {
+ public:
+@@ -166,9 +163,7 @@
+ public:
+   S(): R() {}
+ };
+-],
+-[C c; S s;],
+- omni_cv_cxx_need_fq_base_ctor=no, omni_cv_cxx_need_fq_base_ctor=yes)
++]], [[C c; S s;]])],[omni_cv_cxx_need_fq_base_ctor=no],[omni_cv_cxx_need_fq_base_ctor=yes])
+  AC_LANG_POP(C++)
+ ])
+ if test "$omni_cv_cxx_need_fq_base_ctor" = yes; then
+@@ -181,7 +176,7 @@
+ [AC_CACHE_CHECK(whether the compiler supports covariant return types,
+ omni_cv_cxx_covariant_returns,
+ [AC_LANG_PUSH(C++)
+- AC_TRY_COMPILE([
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ class A {};
+ class B : public virtual A {};
+ class C {
+@@ -192,9 +187,7 @@
+ public:
+   virtual B* test();
+ };
+-],
+-[D d;],
+- omni_cv_cxx_covariant_returns=yes, omni_cv_cxx_covariant_returns=no)
++]], [[D d;]])],[omni_cv_cxx_covariant_returns=yes],[omni_cv_cxx_covariant_returns=no])
+  AC_LANG_POP(C++)
+ ])
+ if test "$omni_cv_cxx_covariant_returns" = yes; then
+@@ -208,11 +201,10 @@
+ [AC_CACHE_CHECK(whether long is the same type as int,
+ omni_cv_cxx_long_is_int,
+ [AC_LANG_PUSH(C++)
+- AC_TRY_COMPILE([
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ int f(int  x){return 1;}
+ int f(long x){return 1;}
+-],[long l = 5; return f(l);],
+- omni_cv_cxx_long_is_int=no, omni_cv_cxx_long_is_int=yes)
++]], [[long l = 5; return f(l);]])],[omni_cv_cxx_long_is_int=no],[omni_cv_cxx_long_is_int=yes])
+  AC_LANG_POP(C++)
+ ])
+ if test "$omni_cv_cxx_long_is_int" = yes; then
+@@ -225,7 +217,7 @@
+ [AC_CACHE_CHECK(whether SIG_IGN is available,
+ omni_cv_sig_ign_available,
+ [AC_LANG_PUSH(C++)
+- AC_TRY_COMPILE([
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #ifdef HAVE_SIGNAL_H
+ #include <signal.h>
+ #else
+@@ -234,12 +226,11 @@
+ #ifndef HAVE_SIGACTION
+ extern "C" int sigaction(int, const struct sigaction *, struct sigaction *);
+ #endif
+-],[
++]], [[
+     struct sigaction act;
+     sigemptyset(&act.sa_mask);
+     act.sa_handler = SIG_IGN;
+-],
+- omni_cv_sig_ign_available=yes, omni_cv_sig_ign_available=no)
++]])],[omni_cv_sig_ign_available=yes],[omni_cv_sig_ign_available=no])
+  AC_LANG_POP(C++)
+ ])
+ if test "$omni_cv_sig_ign_available" = yes; then
+@@ -251,17 +242,16 @@
+ [AC_CACHE_CHECK(whether gettimeofday() takes a timezone argument,
+ omni_cv_gettimeofday_timezone,
+ [AC_LANG_PUSH(C++)
+- AC_TRY_COMPILE([
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #ifdef HAVE_GETTIMEOFDAY
+ #include <sys/time.h>
+ #else
+ die here
+ #endif
+-],[
++]], [[
+   struct timeval v;
+   gettimeofday(&v, 0);
+-],
+- omni_cv_gettimeofday_timezone=yes, omni_cv_gettimeofday_timezone=no)
++]])],[omni_cv_gettimeofday_timezone=yes],[omni_cv_gettimeofday_timezone=no])
+  AC_LANG_POP(C++)
+ ])
+ if test "$omni_cv_gettimeofday_timezone" = yes; then
+@@ -275,14 +265,13 @@
+ [AC_CACHE_CHECK(for IsNANorINF,
+ omni_cv_have_isnanorinf,
+ [AC_LANG_PUSH(C++)
+- AC_TRY_COMPILE([
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #include <math.h>
+ #include <nan.h>
+-],[
++]], [[
+   double d = 1.23;
+   int i = IsNANorINF(d);
+-],
+- omni_cv_have_isnanorinf=yes, omni_cv_have_isnanorinf=no)
++]])],[omni_cv_have_isnanorinf=yes],[omni_cv_have_isnanorinf=no])
+  AC_LANG_POP(C++)
+ ])
+ if test "$omni_cv_have_isnanorinf" = yes; then
+@@ -295,29 +284,27 @@
+ [AC_MSG_CHECKING([third argument of getsockname])
+  omni_cv_sockname_size_t=no
+  AC_LANG_PUSH(C++)
+- AC_TRY_COMPILE([
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+ #include <unistd.h>
+-],[
++]], [[
+   socklen_t l;
+   getsockname(0, 0, &l);
+-],
+- omni_cv_sockname_size_t=socklen_t)
++]])],[omni_cv_sockname_size_t=socklen_t],[])
+  if test "$omni_cv_sockname_size_t" = no; then
+- AC_TRY_COMPILE([
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+ #include <unistd.h>
+-],[
++]], [[
+   size_t l;
+   getsockname(0, 0, &l);
+-],
+- omni_cv_sockname_size_t=size_t, omni_cv_sockname_size_t=int)
++]])],[omni_cv_sockname_size_t=size_t],[omni_cv_sockname_size_t=int])
+  fi
+  AC_DEFINE_UNQUOTED(OMNI_SOCKNAME_SIZE_T, $omni_cv_sockname_size_t,
+                     [Define to the type of getsockname's third argument])
+@@ -328,8 +315,7 @@
+ [AC_CACHE_CHECK(omniORB config file location,
+ omni_cv_omniorb_config,
+ [AC_ARG_WITH(omniORB-config,
+-             AC_HELP_STRING([--with-omniORB-config],
+-               [location of omniORB config file (default /etc/omniORB.cfg)]),
++             AS_HELP_STRING([--with-omniORB-config],[location of omniORB config file (default /etc/omniORB.cfg)]),
+              omni_cv_omniorb_config=$withval,
+              omni_cv_omniorb_config="/etc/omniORB.cfg")
+ ])
+@@ -344,8 +330,7 @@
+ [AC_CACHE_CHECK(omniNames log directory,
+ omni_cv_omninames_logdir,
+ [AC_ARG_WITH(omniNames-logdir,
+-             AC_HELP_STRING([--with-omniNames-logdir],
+-               [location of omniNames log directory (default /var/omninames)]),
++             AS_HELP_STRING([--with-omniNames-logdir],[location of omniNames log directory (default /var/omninames)]),
+              omni_cv_omninames_logdir=$withval,
+              omni_cv_omninames_logdir="/var/omninames")
+ ])
+@@ -360,8 +345,7 @@
+ [AC_CACHE_CHECK(whether to build static libraries,
+ omni_cv_enable_static,
+ [AC_ARG_ENABLE(static,
+-               AC_HELP_STRING([--disable-static],
+-                  [disable build of static libraries (default enable-static)]),
++               AS_HELP_STRING([--disable-static],[disable build of static libraries (default enable-static)]),
+                omni_cv_enable_static=$enableval,
+                omni_cv_enable_static=yes)
+ ])
+@@ -374,8 +358,7 @@
+ [AC_CACHE_CHECK(whether to trace threads and locking,
+ omni_cv_enable_thread_tracing,
+ [AC_ARG_ENABLE(thread-tracing,
+-               AC_HELP_STRING([--enable-thread-tracing],
+-                  [enable thread and mutex tracing (default disable-thread-tracing)]),
++               AS_HELP_STRING([--enable-thread-tracing],[enable thread and mutex tracing (default disable-thread-tracing)]),
+                omni_cv_enable_thread_tracing=$enableval,
+                omni_cv_enable_thread_tracing=no)
+ ])
+@@ -390,8 +373,7 @@
+ [AC_CACHE_CHECK(whether to support IPv6,
+ omni_cv_enable_ipv6,
+ [AC_ARG_ENABLE(ipv6,
+-               AC_HELP_STRING([--disable-ipv6],
+-                  [disable IPv6 support (default enable-ipv6)]),
++               AS_HELP_STRING([--disable-ipv6],[disable IPv6 support (default enable-ipv6)]),
+                omni_cv_enable_ipv6=$enableval,
+                omni_cv_enable_ipv6=yes)
+ ])
+@@ -405,8 +387,7 @@
+ [AC_CACHE_CHECK(whether alloca should be used in omnicpp,
+ omni_cv_enable_alloca,
+ [AC_ARG_ENABLE(alloca,
+-               AC_HELP_STRING([--disable-alloca],
+-                  [disable use of alloca in omnicpp (default enable-alloca)]),
++               AS_HELP_STRING([--disable-alloca],[disable use of alloca in omnicpp (default enable-alloca)]),
+                omni_cv_enable_alloca=$enableval,
+                omni_cv_enable_alloca=yes)
+ ])
+@@ -420,8 +401,7 @@
+ [AC_CACHE_CHECK(whether to support long double,
+ omni_cv_enable_longdouble,
+ [AC_ARG_ENABLE(longdouble,
+-               AC_HELP_STRING([--disable-longdouble],
+-                  [disable long double support (default enable-longdouble)]),
++               AS_HELP_STRING([--disable-longdouble],[disable long double support (default enable-longdouble)]),
+                omni_cv_enable_longdouble=$enableval,
+                omni_cv_enable_longdouble=yes)
+ ])
+@@ -465,8 +445,7 @@
+ [AC_CACHE_CHECK(whether to use atomic operations when possible,
+ omni_cv_enable_atomic,
+ [AC_ARG_ENABLE(atomic,
+-               AC_HELP_STRING([--disable-atomic],
+-                  [disable atomic operations (default enable-atomic)]),
++               AS_HELP_STRING([--disable-atomic],[disable atomic operations (default enable-atomic)]),
+                omni_cv_enable_atomic=$enableval,
+                omni_cv_enable_atomic=yes)
+ ])
+@@ -482,8 +461,7 @@
+ [AC_CACHE_CHECK(whether to use CFNetwork,
+ omni_cv_enable_cfnetwork,
+ [AC_ARG_ENABLE(cfnetwork,
+-               AC_HELP_STRING([--enable-cfnetwork],
+-                  [enable use of Mac / iOS CFNetwork (default disable-cfnetwork)]),
++               AS_HELP_STRING([--enable-cfnetwork],[enable use of Mac / iOS CFNetwork (default disable-cfnetwork)]),
+                omni_cv_enable_cfnetwork=$enableval,
+                omni_cv_enable_cfnetwork=no)
+ ])
+@@ -503,9 +481,8 @@
+ [AC_CACHE_CHECK(whether the compiler supports exceptions,
+ ac_cv_cxx_exceptions,
+ [AC_LANG_SAVE
+- AC_LANG_CPLUSPLUS
+- AC_TRY_COMPILE(,[try { throw  1; } catch (int i) { return i; }],
+- ac_cv_cxx_exceptions=yes, ac_cv_cxx_exceptions=no)
++ AC_LANG([C++])
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[try { throw  1; } catch (int i) { return i; }]])],[ac_cv_cxx_exceptions=yes],[ac_cv_cxx_exceptions=no])
+  AC_LANG_RESTORE
+ ])
+ if test "$ac_cv_cxx_exceptions" = yes; then
+@@ -517,13 +494,12 @@
+ [AC_CACHE_CHECK(whether the compiler recognizes bool as a built-in type,
+ ac_cv_cxx_bool,
+ [AC_LANG_SAVE
+- AC_LANG_CPLUSPLUS
+- AC_TRY_COMPILE([
++ AC_LANG([C++])
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ int f(int  x){return 1;}
+ int f(char x){return 1;}
+ int f(bool x){return 1;}
+-],[bool b = true; return f(b);],
+- ac_cv_cxx_bool=yes, ac_cv_cxx_bool=no)
++]], [[bool b = true; return f(b);]])],[ac_cv_cxx_bool=yes],[ac_cv_cxx_bool=no])
+  AC_LANG_RESTORE
+ ])
+ if test "$ac_cv_cxx_bool" = yes; then
+@@ -535,9 +511,8 @@
+ [AC_CACHE_CHECK(whether the compiler supports const_cast<>,
+ ac_cv_cxx_const_cast,
+ [AC_LANG_SAVE
+- AC_LANG_CPLUSPLUS
+- AC_TRY_COMPILE(,[int x = 0;const int& y = x;int& z = const_cast<int&>(y);return z;],
+- ac_cv_cxx_const_cast=yes, ac_cv_cxx_const_cast=no)
++ AC_LANG([C++])
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[int x = 0;const int& y = x;int& z = const_cast<int&>(y);return z;]])],[ac_cv_cxx_const_cast=yes],[ac_cv_cxx_const_cast=no])
+  AC_LANG_RESTORE
+ ])
+ if test "$ac_cv_cxx_const_cast" = yes; then
+@@ -549,12 +524,11 @@
+ [AC_CACHE_CHECK(whether the compiler supports dynamic_cast<>,
+ ac_cv_cxx_dynamic_cast,
+ [AC_LANG_SAVE
+- AC_LANG_CPLUSPLUS
+- AC_TRY_COMPILE([#include <typeinfo>
++ AC_LANG([C++])
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <typeinfo>
+ class Base { public : Base () {} virtual void f () = 0;};
+-class Derived : public Base { public : Derived () {} virtual void f () {} };],[
+-Derived d; Base& b=d; return dynamic_cast<Derived*>(&b) ? 0 : 1;],
+- ac_cv_cxx_dynamic_cast=yes, ac_cv_cxx_dynamic_cast=no)
++class Derived : public Base { public : Derived () {} virtual void f () {} };]], [[
++Derived d; Base& b=d; return dynamic_cast<Derived*>(&b) ? 0 : 1;]])],[ac_cv_cxx_dynamic_cast=yes],[ac_cv_cxx_dynamic_cast=no])
+  AC_LANG_RESTORE
+ ])
+ if test "$ac_cv_cxx_dynamic_cast" = yes; then
+@@ -566,14 +540,13 @@
+ [AC_CACHE_CHECK(whether the compiler supports reinterpret_cast<>,
+ ac_cv_cxx_reinterpret_cast,
+ [AC_LANG_SAVE
+- AC_LANG_CPLUSPLUS
+- AC_TRY_COMPILE([#include <typeinfo>
++ AC_LANG([C++])
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <typeinfo>
+ class Base { public : Base () {} virtual void f () = 0;};
+ class Derived : public Base { public : Derived () {} virtual void f () {} };
+ class Unrelated { public : Unrelated () {} };
+-int g (Unrelated&) { return 0; }],[
+-Derived d;Base& b=d;Unrelated& e=reinterpret_cast<Unrelated&>(b);return g(e);],
+- ac_cv_cxx_reinterpret_cast=yes, ac_cv_cxx_reinterpret_cast=no)
++int g (Unrelated&) { return 0; }]], [[
++Derived d;Base& b=d;Unrelated& e=reinterpret_cast<Unrelated&>(b);return g(e);]])],[ac_cv_cxx_reinterpret_cast=yes],[ac_cv_cxx_reinterpret_cast=no])
+  AC_LANG_RESTORE
+ ])
+ if test "$ac_cv_cxx_reinterpret_cast" = yes; then
+@@ -586,10 +559,8 @@
+ [AC_CACHE_CHECK(whether the compiler implements namespaces,
+ ac_cv_cxx_namespaces,
+ [AC_LANG_SAVE
+- AC_LANG_CPLUSPLUS
+- AC_TRY_COMPILE([namespace Outer { namespace Inner { int i = 0; }}],
+-                [using namespace Outer::Inner; return i;],
+- ac_cv_cxx_namespaces=yes, ac_cv_cxx_namespaces=no)
++ AC_LANG([C++])
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[namespace Outer { namespace Inner { int i = 0; }}]], [[using namespace Outer::Inner; return i;]])],[ac_cv_cxx_namespaces=yes],[ac_cv_cxx_namespaces=no])
+  AC_LANG_RESTORE
+ ])
+ if test "$ac_cv_cxx_namespaces" = yes; then
+@@ -602,15 +573,14 @@
+ ac_cv_cxx_have_std,
+ [AC_REQUIRE([AC_CXX_NAMESPACES])
+  AC_LANG_SAVE
+- AC_LANG_CPLUSPLUS
+- AC_TRY_COMPILE([#include <iostream>
++ AC_LANG([C++])
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <iostream>
+ #include <map>
+ #include <iomanip>
+ #include <cmath>
+ #ifdef HAVE_NAMESPACES
+ using namespace std;
+-#endif],[return 0;],
+- ac_cv_cxx_have_std=yes, ac_cv_cxx_have_std=no)
++#endif]], [[return 0;]])],[ac_cv_cxx_have_std=yes],[ac_cv_cxx_have_std=no])
+  AC_LANG_RESTORE
+ ])
+ if test "$ac_cv_cxx_have_std" = yes; then
+@@ -622,10 +592,8 @@
+ [AC_CACHE_CHECK(whether the compiler supports member constants,
+ ac_cv_cxx_member_constants,
+ [AC_LANG_SAVE
+- AC_LANG_CPLUSPLUS
+- AC_TRY_COMPILE([class C {public: static const int i = 0;}; const int C::i;],
+-[return C::i;],
+- ac_cv_cxx_member_constants=yes, ac_cv_cxx_member_constants=no)
++ AC_LANG([C++])
++ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[class C {public: static const int i = 0;}; const int C::i;]], [[return C::i;]])],[ac_cv_cxx_member_constants=yes],[ac_cv_cxx_member_constants=no])
+  AC_LANG_RESTORE
+ ])
+ if test "$ac_cv_cxx_member_constants" = yes; then
+Index: omniORB/aclocal.m4
+===================================================================
+--- omniORB/aclocal.m4	(revision 6647)
++++ omniORB/aclocal.m4	(revision 6648)
+@@ -1,6 +1,6 @@
+-# generated automatically by aclocal 1.16.1 -*- Autoconf -*-
++# generated automatically by aclocal 1.16.5 -*- Autoconf -*-
+ 
+-# Copyright (C) 1996-2018 Free Software Foundation, Inc.
++# Copyright (C) 1996-2021 Free Software Foundation, Inc.
+ 
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -356,7 +356,7 @@
+         [AC_DEFINE([HAVE_][$1], 1, [Enable ]m4_tolower([$1])[ support])])
+ ])dnl PKG_HAVE_DEFINE_WITH_MODULES
+ 
+-# Copyright (C) 1999-2018 Free Software Foundation, Inc.
++# Copyright (C) 1999-2021 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -435,34 +435,141 @@
+   ])
+ 
+   if test "$PYTHON" = :; then
+-  dnl Run any user-specified action, or abort.
++    dnl Run any user-specified action, or abort.
+     m4_default([$3], [AC_MSG_ERROR([no suitable Python interpreter found])])
+   else
+ 
+-  dnl Query Python for its version number.  Getting [:3] seems to be
+-  dnl the best way to do this; it's what "site.py" does in the standard
+-  dnl library.
+-
++  dnl Query Python for its version number.  Although site.py simply uses
++  dnl sys.version[:3], printing that failed with Python 3.10, since the
++  dnl trailing zero was eliminated. So now we output just the major
++  dnl and minor version numbers, as numbers. Apparently the tertiary
++  dnl version is not of interest.
++  dnl
+   AC_CACHE_CHECK([for $am_display_PYTHON version], [am_cv_python_version],
+-    [am_cv_python_version=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:3]])"`])
++    [am_cv_python_version=`$PYTHON -c "import sys; print ('%u.%u' % sys.version_info[[:2]])"`])
+   AC_SUBST([PYTHON_VERSION], [$am_cv_python_version])
+ 
+-  dnl Use the values of $prefix and $exec_prefix for the corresponding
+-  dnl values of PYTHON_PREFIX and PYTHON_EXEC_PREFIX.  These are made
+-  dnl distinct variables so they can be overridden if need be.  However,
+-  dnl general consensus is that you shouldn't need this ability.
+-
+-  AC_SUBST([PYTHON_PREFIX], ['${prefix}'])
+-  AC_SUBST([PYTHON_EXEC_PREFIX], ['${exec_prefix}'])
+-
+-  dnl At times (like when building shared libraries) you may want
++  dnl At times, e.g., when building shared libraries, you may want
+   dnl to know which OS platform Python thinks this is.
+-
++  dnl
+   AC_CACHE_CHECK([for $am_display_PYTHON platform], [am_cv_python_platform],
+     [am_cv_python_platform=`$PYTHON -c "import sys; sys.stdout.write(sys.platform)"`])
+   AC_SUBST([PYTHON_PLATFORM], [$am_cv_python_platform])
+ 
+-  # Just factor out some code duplication.
++  dnl emacs-page
++  dnl If --with-python-sys-prefix is given, use the values of sys.prefix
++  dnl and sys.exec_prefix for the corresponding values of PYTHON_PREFIX
++  dnl and PYTHON_EXEC_PREFIX. Otherwise, use the GNU ${prefix} and
++  dnl ${exec_prefix} variables.
++  dnl
++  dnl The two are made distinct variables so they can be overridden if
++  dnl need be, although general consensus is that you shouldn't need
++  dnl this separation.
++  dnl
++  dnl Also allow directly setting the prefixes via configure options,
++  dnl overriding any default.
++  dnl
++  if test "x$prefix" = xNONE; then
++    am__usable_prefix=$ac_default_prefix
++  else
++    am__usable_prefix=$prefix
++  fi
++
++  # Allow user to request using sys.* values from Python,
++  # instead of the GNU $prefix values.
++  AC_ARG_WITH([python-sys-prefix],
++  [AS_HELP_STRING([--with-python-sys-prefix],
++                  [use Python's sys.prefix and sys.exec_prefix values])],
++  [am_use_python_sys=:],
++  [am_use_python_sys=false])
++
++  # Allow user to override whatever the default Python prefix is.
++  AC_ARG_WITH([python_prefix],
++  [AS_HELP_STRING([--with-python_prefix],
++                  [override the default PYTHON_PREFIX])],
++  [am_python_prefix_subst=$withval
++   am_cv_python_prefix=$withval
++   AC_MSG_CHECKING([for explicit $am_display_PYTHON prefix])
++   AC_MSG_RESULT([$am_cv_python_prefix])],
++  [
++   if $am_use_python_sys; then
++     # using python sys.prefix value, not GNU
++     AC_CACHE_CHECK([for python default $am_display_PYTHON prefix],
++     [am_cv_python_prefix],
++     [am_cv_python_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.prefix)"`])
++
++     dnl If sys.prefix is a subdir of $prefix, replace the literal value of
++     dnl $prefix with a variable reference so it can be overridden.
++     case $am_cv_python_prefix in
++     $am__usable_prefix*)
++       am__strip_prefix=`echo "$am__usable_prefix" | sed 's|.|.|g'`
++       am_python_prefix_subst=`echo "$am_cv_python_prefix" | sed "s,^$am__strip_prefix,\\${prefix},"`
++       ;;
++     *)
++       am_python_prefix_subst=$am_cv_python_prefix
++       ;;
++     esac
++   else # using GNU prefix value, not python sys.prefix
++     am_python_prefix_subst='${prefix}'
++     am_python_prefix=$am_python_prefix_subst
++     AC_MSG_CHECKING([for GNU default $am_display_PYTHON prefix])
++     AC_MSG_RESULT([$am_python_prefix])
++   fi])
++  # Substituting python_prefix_subst value.
++  AC_SUBST([PYTHON_PREFIX], [$am_python_prefix_subst])
++
++  # emacs-page Now do it all over again for Python exec_prefix, but with yet
++  # another conditional: fall back to regular prefix if that was specified.
++  AC_ARG_WITH([python_exec_prefix],
++  [AS_HELP_STRING([--with-python_exec_prefix],
++                  [override the default PYTHON_EXEC_PREFIX])],
++  [am_python_exec_prefix_subst=$withval
++   am_cv_python_exec_prefix=$withval
++   AC_MSG_CHECKING([for explicit $am_display_PYTHON exec_prefix])
++   AC_MSG_RESULT([$am_cv_python_exec_prefix])],
++  [
++   # no explicit --with-python_exec_prefix, but if
++   # --with-python_prefix was given, use its value for python_exec_prefix too.
++   AS_IF([test -n "$with_python_prefix"],
++   [am_python_exec_prefix_subst=$with_python_prefix
++    am_cv_python_exec_prefix=$with_python_prefix
++    AC_MSG_CHECKING([for python_prefix-given $am_display_PYTHON exec_prefix])
++    AC_MSG_RESULT([$am_cv_python_exec_prefix])],
++   [
++    # Set am__usable_exec_prefix whether using GNU or Python values,
++    # since we use that variable for pyexecdir.
++    if test "x$exec_prefix" = xNONE; then
++      am__usable_exec_prefix=$am__usable_prefix
++    else
++      am__usable_exec_prefix=$exec_prefix
++    fi
++    #
++    if $am_use_python_sys; then # using python sys.exec_prefix, not GNU
++      AC_CACHE_CHECK([for python default $am_display_PYTHON exec_prefix],
++      [am_cv_python_exec_prefix],
++      [am_cv_python_exec_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.exec_prefix)"`])
++      dnl If sys.exec_prefix is a subdir of $exec_prefix, replace the
++      dnl literal value of $exec_prefix with a variable reference so it can
++      dnl be overridden.
++      case $am_cv_python_exec_prefix in
++      $am__usable_exec_prefix*)
++        am__strip_prefix=`echo "$am__usable_exec_prefix" | sed 's|.|.|g'`
++        am_python_exec_prefix_subst=`echo "$am_cv_python_exec_prefix" | sed "s,^$am__strip_prefix,\\${exec_prefix},"`
++        ;;
++      *)
++        am_python_exec_prefix_subst=$am_cv_python_exec_prefix
++        ;;
++     esac
++   else # using GNU $exec_prefix, not python sys.exec_prefix
++     am_python_exec_prefix_subst='${exec_prefix}'
++     am_python_exec_prefix=$am_python_exec_prefix_subst
++     AC_MSG_CHECKING([for GNU default $am_display_PYTHON exec_prefix])
++     AC_MSG_RESULT([$am_python_exec_prefix])
++   fi])])
++  # Substituting python_exec_prefix_subst.
++  AC_SUBST([PYTHON_EXEC_PREFIX], [$am_python_exec_prefix_subst])
++
++  # Factor out some code duplication into this shell variable.
+   am_python_setup_sysconfig="\
+ import sys
+ # Prefer sysconfig over distutils.sysconfig, for better compatibility
+@@ -482,96 +589,95 @@
+ except ImportError:
+     pass"
+ 
+-  dnl Set up 4 directories:
++  dnl emacs-page Set up 4 directories:
+ 
+-  dnl pythondir -- where to install python scripts.  This is the
+-  dnl   site-packages directory, not the python standard library
+-  dnl   directory like in previous automake betas.  This behavior
+-  dnl   is more consistent with lispdir.m4 for example.
++  dnl 1. pythondir: where to install python scripts.  This is the
++  dnl    site-packages directory, not the python standard library
++  dnl    directory like in previous automake betas.  This behavior
++  dnl    is more consistent with lispdir.m4 for example.
+   dnl Query distutils for this directory.
+-  AC_CACHE_CHECK([for $am_display_PYTHON script directory],
+-    [am_cv_python_pythondir],
+-    [if test "x$prefix" = xNONE
+-     then
+-       am_py_prefix=$ac_default_prefix
+-     else
+-       am_py_prefix=$prefix
+-     fi
+-     am_cv_python_pythondir=`$PYTHON -c "
++  dnl
++  AC_CACHE_CHECK([for $am_display_PYTHON script directory (pythondir)],
++  [am_cv_python_pythondir],
++  [if test "x$am_cv_python_prefix" = x; then
++     am_py_prefix=$am__usable_prefix
++   else
++     am_py_prefix=$am_cv_python_prefix
++   fi
++   am_cv_python_pythondir=`$PYTHON -c "
+ $am_python_setup_sysconfig
+ if can_use_sysconfig:
+-    sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
++  sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
+ else:
+-    from distutils import sysconfig
+-    sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
++  from distutils import sysconfig
++  sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
+ sys.stdout.write(sitedir)"`
+-     case $am_cv_python_pythondir in
+-     $am_py_prefix*)
+-       am__strip_prefix=`echo "$am_py_prefix" | sed 's|.|.|g'`
+-       am_cv_python_pythondir=`echo "$am_cv_python_pythondir" | sed "s,^$am__strip_prefix,$PYTHON_PREFIX,"`
+-       ;;
+-     *)
+-       case $am_py_prefix in
+-         /usr|/System*) ;;
+-         *)
+-	  am_cv_python_pythondir=$PYTHON_PREFIX/lib/python$PYTHON_VERSION/site-packages
+-	  ;;
+-       esac
+-       ;;
++   #
++   case $am_cv_python_pythondir in
++   $am_py_prefix*)
++     am__strip_prefix=`echo "$am_py_prefix" | sed 's|.|.|g'`
++     am_cv_python_pythondir=`echo "$am_cv_python_pythondir" | sed "s,^$am__strip_prefix,\\${PYTHON_PREFIX},"`
++     ;;
++   *)
++     case $am_py_prefix in
++       /usr|/System*) ;;
++       *) am_cv_python_pythondir="\${PYTHON_PREFIX}/lib/python$PYTHON_VERSION/site-packages"
++          ;;
+      esac
+-    ])
++     ;;
++   esac
++  ])
+   AC_SUBST([pythondir], [$am_cv_python_pythondir])
+ 
+-  dnl pkgpythondir -- $PACKAGE directory under pythondir.  Was
+-  dnl   PYTHON_SITE_PACKAGE in previous betas, but this naming is
+-  dnl   more consistent with the rest of automake.
+-
++  dnl 2. pkgpythondir: $PACKAGE directory under pythondir.  Was
++  dnl    PYTHON_SITE_PACKAGE in previous betas, but this naming is
++  dnl    more consistent with the rest of automake.
++  dnl
+   AC_SUBST([pkgpythondir], [\${pythondir}/$PACKAGE])
+ 
+-  dnl pyexecdir -- directory for installing python extension modules
+-  dnl   (shared libraries)
++  dnl 3. pyexecdir: directory for installing python extension modules
++  dnl    (shared libraries).
+   dnl Query distutils for this directory.
+-  AC_CACHE_CHECK([for $am_display_PYTHON extension module directory],
+-    [am_cv_python_pyexecdir],
+-    [if test "x$exec_prefix" = xNONE
+-     then
+-       am_py_exec_prefix=$am_py_prefix
+-     else
+-       am_py_exec_prefix=$exec_prefix
+-     fi
+-     am_cv_python_pyexecdir=`$PYTHON -c "
++  dnl
++  AC_CACHE_CHECK([for $am_display_PYTHON extension module directory (pyexecdir)],
++  [am_cv_python_pyexecdir],
++  [if test "x$am_cv_python_exec_prefix" = x; then
++     am_py_exec_prefix=$am__usable_exec_prefix
++   else
++     am_py_exec_prefix=$am_cv_python_exec_prefix
++   fi
++   am_cv_python_pyexecdir=`$PYTHON -c "
+ $am_python_setup_sysconfig
+ if can_use_sysconfig:
+-    sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_prefix'})
++  sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_exec_prefix'})
+ else:
+-    from distutils import sysconfig
+-    sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_prefix')
++  from distutils import sysconfig
++  sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_exec_prefix')
+ sys.stdout.write(sitedir)"`
+-     case $am_cv_python_pyexecdir in
+-     $am_py_exec_prefix*)
+-       am__strip_prefix=`echo "$am_py_exec_prefix" | sed 's|.|.|g'`
+-       am_cv_python_pyexecdir=`echo "$am_cv_python_pyexecdir" | sed "s,^$am__strip_prefix,$PYTHON_EXEC_PREFIX,"`
+-       ;;
+-     *)
+-       case $am_py_exec_prefix in
+-         /usr|/System*) ;;
+-         *)
+-	   am_cv_python_pyexecdir=$PYTHON_EXEC_PREFIX/lib/python$PYTHON_VERSION/site-packages
+-	   ;;
+-       esac
+-       ;;
++   #
++   case $am_cv_python_pyexecdir in
++   $am_py_exec_prefix*)
++     am__strip_prefix=`echo "$am_py_exec_prefix" | sed 's|.|.|g'`
++     am_cv_python_pyexecdir=`echo "$am_cv_python_pyexecdir" | sed "s,^$am__strip_prefix,\\${PYTHON_EXEC_PREFIX},"`
++     ;;
++   *)
++     case $am_py_exec_prefix in
++       /usr|/System*) ;;
++       *) am_cv_python_pyexecdir="\${PYTHON_EXEC_PREFIX}/lib/python$PYTHON_VERSION/site-packages"
++          ;;
+      esac
+-    ])
++     ;;
++   esac
++  ])
+   AC_SUBST([pyexecdir], [$am_cv_python_pyexecdir])
+ 
+-  dnl pkgpyexecdir -- $(pyexecdir)/$(PACKAGE)
+-
++  dnl 4. pkgpyexecdir: $(pyexecdir)/$(PACKAGE)
++  dnl
+   AC_SUBST([pkgpyexecdir], [\${pyexecdir}/$PACKAGE])
+ 
+   dnl Run any user-specified action.
+   $2
+   fi
+-
+ ])
+ 
+ 
+Index: omniORB/configure
+===================================================================
+--- omniORB/configure	(revision 6647)
++++ omniORB/configure	(revision 6648)
+@@ -1,11 +1,12 @@
+ #! /bin/sh
+ # Guess values for system-dependent variables and create Makefiles.
+-# Generated by GNU Autoconf 2.69 for omniORB 4.2.5.
++# Generated by GNU Autoconf 2.71 for omniORB 4.2.5.
+ #
+ # Report bugs to <bugs@omniorb-support.com>.
+ #
+ #
+-# Copyright (C) 1992-1996, 1998-2012 Free Software Foundation, Inc.
++# Copyright (C) 1992-1996, 1998-2017, 2020-2021 Free Software Foundation,
++# Inc.
+ #
+ #
+ # This configure script is free software; the Free Software Foundation
+@@ -16,7 +17,9 @@
+ 
+ # Be more Bourne compatible
+ DUALCASE=1; export DUALCASE # for MKS sh
+-if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :
++as_nop=:
++if test ${ZSH_VERSION+y} && (emulate sh) >/dev/null 2>&1
++then :
+   emulate sh
+   NULLCMD=:
+   # Pre-4.2 versions of Zsh do word splitting on ${1+"$@"}, which
+@@ -23,7 +26,7 @@
+   # is contrary to our usage.  Disable this feature.
+   alias -g '${1+"$@"}'='"$@"'
+   setopt NO_GLOB_SUBST
+-else
++else $as_nop
+   case `(set -o) 2>/dev/null` in #(
+   *posix*) :
+     set -o posix ;; #(
+@@ -33,46 +36,46 @@
+ fi
+ 
+ 
++
++# Reset variables that may have inherited troublesome values from
++# the environment.
++
++# IFS needs to be set, to space, tab, and newline, in precisely that order.
++# (If _AS_PATH_WALK were called with IFS unset, it would have the
++# side effect of setting IFS to empty, thus disabling word splitting.)
++# Quoting is to prevent editors from complaining about space-tab.
+ as_nl='
+ '
+ export as_nl
+-# Printing a long string crashes Solaris 7 /usr/bin/printf.
+-as_echo='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+-as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo
+-as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo$as_echo
+-# Prefer a ksh shell builtin over an external printf program on Solaris,
+-# but without wasting forks for bash or zsh.
+-if test -z "$BASH_VERSION$ZSH_VERSION" \
+-    && (test "X`print -r -- $as_echo`" = "X$as_echo") 2>/dev/null; then
+-  as_echo='print -r --'
+-  as_echo_n='print -rn --'
+-elif (test "X`printf %s $as_echo`" = "X$as_echo") 2>/dev/null; then
+-  as_echo='printf %s\n'
+-  as_echo_n='printf %s'
+-else
+-  if test "X`(/usr/ucb/echo -n -n $as_echo) 2>/dev/null`" = "X-n $as_echo"; then
+-    as_echo_body='eval /usr/ucb/echo -n "$1$as_nl"'
+-    as_echo_n='/usr/ucb/echo -n'
+-  else
+-    as_echo_body='eval expr "X$1" : "X\\(.*\\)"'
+-    as_echo_n_body='eval
+-      arg=$1;
+-      case $arg in #(
+-      *"$as_nl"*)
+-	expr "X$arg" : "X\\(.*\\)$as_nl";
+-	arg=`expr "X$arg" : ".*$as_nl\\(.*\\)"`;;
+-      esac;
+-      expr "X$arg" : "X\\(.*\\)" | tr -d "$as_nl"
+-    '
+-    export as_echo_n_body
+-    as_echo_n='sh -c $as_echo_n_body as_echo'
+-  fi
+-  export as_echo_body
+-  as_echo='sh -c $as_echo_body as_echo'
+-fi
++IFS=" ""	$as_nl"
+ 
++PS1='$ '
++PS2='> '
++PS4='+ '
++
++# Ensure predictable behavior from utilities with locale-dependent output.
++LC_ALL=C
++export LC_ALL
++LANGUAGE=C
++export LANGUAGE
++
++# We cannot yet rely on "unset" to work, but we need these variables
++# to be unset--not just set to an empty or harmless value--now, to
++# avoid bugs in old shells (e.g. pre-3.0 UWIN ksh).  This construct
++# also avoids known problems related to "unset" and subshell syntax
++# in other old shells (e.g. bash 2.01 and pdksh 5.2.14).
++for as_var in BASH_ENV ENV MAIL MAILPATH CDPATH
++do eval test \${$as_var+y} \
++  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
++done
++
++# Ensure that fds 0, 1, and 2 are open.
++if (exec 3>&0) 2>/dev/null; then :; else exec 0</dev/null; fi
++if (exec 3>&1) 2>/dev/null; then :; else exec 1>/dev/null; fi
++if (exec 3>&2)            ; then :; else exec 2>/dev/null; fi
++
+ # The user is always right.
+-if test "${PATH_SEPARATOR+set}" != set; then
++if ${PATH_SEPARATOR+false} :; then
+   PATH_SEPARATOR=:
+   (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {
+     (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 ||
+@@ -81,13 +84,6 @@
+ fi
+ 
+ 
+-# IFS
+-# We need space, tab and new line, in precisely that order.  Quoting is
+-# there to prevent editors from complaining about space-tab.
+-# (If _AS_PATH_WALK were called with IFS unset, it would disable word
+-# splitting by setting IFS to empty value.)
+-IFS=" ""	$as_nl"
+-
+ # Find who we are.  Look in the path if we contain no directory separator.
+ as_myself=
+ case $0 in #((
+@@ -96,8 +92,12 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    test -r "$as_dir/$0" && as_myself=$as_dir/$0 && break
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    test -r "$as_dir$0" && as_myself=$as_dir$0 && break
+   done
+ IFS=$as_save_IFS
+ 
+@@ -109,31 +109,11 @@
+   as_myself=$0
+ fi
+ if test ! -f "$as_myself"; then
+-  $as_echo "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
++  printf "%s\n" "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
+   exit 1
+ fi
+ 
+-# Unset variables that we do not need and which cause bugs (e.g. in
+-# pre-3.0 UWIN ksh).  But do not cause bugs in bash 2.01; the "|| exit 1"
+-# suppresses any "Segmentation fault" message there.  '((' could
+-# trigger a bug in pdksh 5.2.14.
+-for as_var in BASH_ENV ENV MAIL MAILPATH
+-do eval test x\${$as_var+set} = xset \
+-  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
+-done
+-PS1='$ '
+-PS2='> '
+-PS4='+ '
+ 
+-# NLS nuisances.
+-LC_ALL=C
+-export LC_ALL
+-LANGUAGE=C
+-export LANGUAGE
+-
+-# CDPATH.
+-(unset CDPATH) >/dev/null 2>&1 && unset CDPATH
+-
+ # Use a proper internal environment variable to ensure we don't fall
+   # into an infinite loop, continuously re-executing ourselves.
+   if test x"${_as_can_reexec}" != xno && test "x$CONFIG_SHELL" != x; then
+@@ -154,13 +134,15 @@
+ exec $CONFIG_SHELL $as_opts "$as_myself" ${1+"$@"}
+ # Admittedly, this is quite paranoid, since all the known shells bail
+ # out after a failed `exec'.
+-$as_echo "$0: could not re-execute with $CONFIG_SHELL" >&2
+-as_fn_exit 255
++printf "%s\n" "$0: could not re-execute with $CONFIG_SHELL" >&2
++exit 255
+   fi
+   # We don't want this to propagate to other subprocesses.
+           { _as_can_reexec=; unset _as_can_reexec;}
+ if test "x$CONFIG_SHELL" = x; then
+-  as_bourne_compatible="if test -n \"\${ZSH_VERSION+set}\" && (emulate sh) >/dev/null 2>&1; then :
++  as_bourne_compatible="as_nop=:
++if test \${ZSH_VERSION+y} && (emulate sh) >/dev/null 2>&1
++then :
+   emulate sh
+   NULLCMD=:
+   # Pre-4.2 versions of Zsh do word splitting on \${1+\"\$@\"}, which
+@@ -167,7 +149,7 @@
+   # is contrary to our usage.  Disable this feature.
+   alias -g '\${1+\"\$@\"}'='\"\$@\"'
+   setopt NO_GLOB_SUBST
+-else
++else \$as_nop
+   case \`(set -o) 2>/dev/null\` in #(
+   *posix*) :
+     set -o posix ;; #(
+@@ -187,12 +169,15 @@
+ as_fn_failure && { exitcode=1; echo as_fn_failure succeeded.; }
+ as_fn_ret_success || { exitcode=1; echo as_fn_ret_success failed.; }
+ as_fn_ret_failure && { exitcode=1; echo as_fn_ret_failure succeeded.; }
+-if ( set x; as_fn_ret_success y && test x = \"\$1\" ); then :
++if ( set x; as_fn_ret_success y && test x = \"\$1\" )
++then :
+ 
+-else
++else \$as_nop
+   exitcode=1; echo positional parameters were not saved.
+ fi
+ test x\$exitcode = x0 || exit 1
++blah=\$(echo \$(echo blah))
++test x\"\$blah\" = xblah || exit 1
+ test -x / || exit 1"
+   as_suggested="  as_lineno_1=";as_suggested=$as_suggested$LINENO;as_suggested=$as_suggested" as_lineno_1a=\$LINENO
+   as_lineno_2=";as_suggested=$as_suggested$LINENO;as_suggested=$as_suggested" as_lineno_2a=\$LINENO
+@@ -199,30 +184,38 @@
+   eval 'test \"x\$as_lineno_1'\$as_run'\" != \"x\$as_lineno_2'\$as_run'\" &&
+   test \"x\`expr \$as_lineno_1'\$as_run' + 1\`\" = \"x\$as_lineno_2'\$as_run'\"' || exit 1
+ test \$(( 1 + 1 )) = 2 || exit 1"
+-  if (eval "$as_required") 2>/dev/null; then :
++  if (eval "$as_required") 2>/dev/null
++then :
+   as_have_required=yes
+-else
++else $as_nop
+   as_have_required=no
+ fi
+-  if test x$as_have_required = xyes && (eval "$as_suggested") 2>/dev/null; then :
++  if test x$as_have_required = xyes && (eval "$as_suggested") 2>/dev/null
++then :
+ 
+-else
++else $as_nop
+   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+ as_found=false
+ for as_dir in /bin$PATH_SEPARATOR/usr/bin$PATH_SEPARATOR$PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+   as_found=:
+   case $as_dir in #(
+ 	 /*)
+ 	   for as_base in sh bash ksh sh5; do
+ 	     # Try only shells that exist, to save several forks.
+-	     as_shell=$as_dir/$as_base
++	     as_shell=$as_dir$as_base
+ 	     if { test -f "$as_shell" || test -f "$as_shell.exe"; } &&
+-		    { $as_echo "$as_bourne_compatible""$as_required" | as_run=a "$as_shell"; } 2>/dev/null; then :
++		    as_run=a "$as_shell" -c "$as_bourne_compatible""$as_required" 2>/dev/null
++then :
+   CONFIG_SHELL=$as_shell as_have_required=yes
+-		   if { $as_echo "$as_bourne_compatible""$as_suggested" | as_run=a "$as_shell"; } 2>/dev/null; then :
++		   if as_run=a "$as_shell" -c "$as_bourne_compatible""$as_suggested" 2>/dev/null
++then :
+   break 2
+ fi
+ fi
+@@ -230,14 +223,21 @@
+        esac
+   as_found=false
+ done
+-$as_found || { if { test -f "$SHELL" || test -f "$SHELL.exe"; } &&
+-	      { $as_echo "$as_bourne_compatible""$as_required" | as_run=a "$SHELL"; } 2>/dev/null; then :
+-  CONFIG_SHELL=$SHELL as_have_required=yes
+-fi; }
+ IFS=$as_save_IFS
++if $as_found
++then :
+ 
++else $as_nop
++  if { test -f "$SHELL" || test -f "$SHELL.exe"; } &&
++	      as_run=a "$SHELL" -c "$as_bourne_compatible""$as_required" 2>/dev/null
++then :
++  CONFIG_SHELL=$SHELL as_have_required=yes
++fi
++fi
+ 
+-      if test "x$CONFIG_SHELL" != x; then :
++
++      if test "x$CONFIG_SHELL" != x
++then :
+   export CONFIG_SHELL
+              # We cannot yet assume a decent shell, so we have to provide a
+ # neutralization value for shells without unset; and this also
+@@ -255,18 +255,19 @@
+ exec $CONFIG_SHELL $as_opts "$as_myself" ${1+"$@"}
+ # Admittedly, this is quite paranoid, since all the known shells bail
+ # out after a failed `exec'.
+-$as_echo "$0: could not re-execute with $CONFIG_SHELL" >&2
++printf "%s\n" "$0: could not re-execute with $CONFIG_SHELL" >&2
+ exit 255
+ fi
+ 
+-    if test x$as_have_required = xno; then :
+-  $as_echo "$0: This script requires a shell more modern than all"
+-  $as_echo "$0: the shells that I found on your system."
+-  if test x${ZSH_VERSION+set} = xset ; then
+-    $as_echo "$0: In particular, zsh $ZSH_VERSION has bugs and should"
+-    $as_echo "$0: be upgraded to zsh 4.3.4 or later."
++    if test x$as_have_required = xno
++then :
++  printf "%s\n" "$0: This script requires a shell more modern than all"
++  printf "%s\n" "$0: the shells that I found on your system."
++  if test ${ZSH_VERSION+y} ; then
++    printf "%s\n" "$0: In particular, zsh $ZSH_VERSION has bugs and should"
++    printf "%s\n" "$0: be upgraded to zsh 4.3.4 or later."
+   else
+-    $as_echo "$0: Please tell bug-autoconf@gnu.org and
++    printf "%s\n" "$0: Please tell bug-autoconf@gnu.org and
+ $0: bugs@omniorb-support.com about your system, including
+ $0: any error possibly output before this message. Then
+ $0: install a modern shell, or manually run the script
+@@ -294,6 +295,7 @@
+ }
+ as_unset=as_fn_unset
+ 
++
+ # as_fn_set_status STATUS
+ # -----------------------
+ # Set $? to STATUS, without forking.
+@@ -311,6 +313,14 @@
+   as_fn_set_status $1
+   exit $1
+ } # as_fn_exit
++# as_fn_nop
++# ---------
++# Do nothing but, unlike ":", preserve the value of $?.
++as_fn_nop ()
++{
++  return $?
++}
++as_nop=as_fn_nop
+ 
+ # as_fn_mkdir_p
+ # -------------
+@@ -325,7 +335,7 @@
+     as_dirs=
+     while :; do
+       case $as_dir in #(
+-      *\'*) as_qdir=`$as_echo "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
++      *\'*) as_qdir=`printf "%s\n" "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
+       *) as_qdir=$as_dir;;
+       esac
+       as_dirs="'$as_qdir' $as_dirs"
+@@ -334,7 +344,7 @@
+ 	 X"$as_dir" : 'X\(//\)[^/]' \| \
+ 	 X"$as_dir" : 'X\(//\)$' \| \
+ 	 X"$as_dir" : 'X\(/\)' \| . 2>/dev/null ||
+-$as_echo X"$as_dir" |
++printf "%s\n" X"$as_dir" |
+     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
+ 	    s//\1/
+ 	    q
+@@ -373,12 +383,13 @@
+ # advantage of any shell optimizations that allow amortized linear growth over
+ # repeated appends, instead of the typical quadratic growth present in naive
+ # implementations.
+-if (eval "as_var=1; as_var+=2; test x\$as_var = x12") 2>/dev/null; then :
++if (eval "as_var=1; as_var+=2; test x\$as_var = x12") 2>/dev/null
++then :
+   eval 'as_fn_append ()
+   {
+     eval $1+=\$2
+   }'
+-else
++else $as_nop
+   as_fn_append ()
+   {
+     eval $1=\$$1\$2
+@@ -390,12 +401,13 @@
+ # Perform arithmetic evaluation on the ARGs, and store the result in the
+ # global $as_val. Take advantage of shells that can avoid forks. The arguments
+ # must be portable across $(()) and expr.
+-if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null; then :
++if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null
++then :
+   eval 'as_fn_arith ()
+   {
+     as_val=$(( $* ))
+   }'
+-else
++else $as_nop
+   as_fn_arith ()
+   {
+     as_val=`expr "$@" || test $? -eq 1`
+@@ -402,6 +414,14 @@
+   }
+ fi # as_fn_arith
+ 
++# as_fn_nop
++# ---------
++# Do nothing but, unlike ":", preserve the value of $?.
++as_fn_nop ()
++{
++  return $?
++}
++as_nop=as_fn_nop
+ 
+ # as_fn_error STATUS ERROR [LINENO LOG_FD]
+ # ----------------------------------------
+@@ -413,9 +433,9 @@
+   as_status=$1; test $as_status -eq 0 && as_status=1
+   if test "$4"; then
+     as_lineno=${as_lineno-"$3"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-    $as_echo "$as_me:${as_lineno-$LINENO}: error: $2" >&$4
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: $2" >&$4
+   fi
+-  $as_echo "$as_me: error: $2" >&2
++  printf "%s\n" "$as_me: error: $2" >&2
+   as_fn_exit $as_status
+ } # as_fn_error
+ 
+@@ -442,7 +462,7 @@
+ $as_expr X/"$0" : '.*/\([^/][^/]*\)/*$' \| \
+ 	 X"$0" : 'X\(//\)$' \| \
+ 	 X"$0" : 'X\(/\)' \| . 2>/dev/null ||
+-$as_echo X/"$0" |
++printf "%s\n" X/"$0" |
+     sed '/^.*\/\([^/][^/]*\)\/*$/{
+ 	    s//\1/
+ 	    q
+@@ -486,7 +506,7 @@
+       s/-\n.*//
+     ' >$as_me.lineno &&
+   chmod +x "$as_me.lineno" ||
+-    { $as_echo "$as_me: error: cannot create $as_me.lineno; rerun with a POSIX shell" >&2; as_fn_exit 1; }
++    { printf "%s\n" "$as_me: error: cannot create $as_me.lineno; rerun with a POSIX shell" >&2; as_fn_exit 1; }
+ 
+   # If we had to re-execute with $CONFIG_SHELL, we're ensured to have
+   # already done that, so ensure we don't try to do so again and fall
+@@ -500,6 +520,10 @@
+   exit
+ }
+ 
++
++# Determine whether it's possible to make 'echo' print without a newline.
++# These variables are no longer used directly by Autoconf, but are AC_SUBSTed
++# for compatibility with existing Makefiles.
+ ECHO_C= ECHO_N= ECHO_T=
+ case `echo -n x` in #(((((
+ -n*)
+@@ -513,6 +537,13 @@
+   ECHO_N='-n';;
+ esac
+ 
++# For backward compatibility with old third-party macros, we provide
++# the shell variables $as_echo and $as_echo_n.  New code should use
++# AS_ECHO(["message"]) and AS_ECHO_N(["message"]), respectively.
++as_echo='printf %s\n'
++as_echo_n='printf %s'
++
++
+ rm -f conf$$ conf$$.exe conf$$.file
+ if test -d conf$$.dir; then
+   rm -f conf$$.dir/conf$$.file
+@@ -588,30 +619,16 @@
+ ac_unique_file="bin/scripts/omkdirhier"
+ # Factoring default headers for most tests.
+ ac_includes_default="\
+-#include <stdio.h>
+-#ifdef HAVE_SYS_TYPES_H
+-# include <sys/types.h>
++#include <stddef.h>
++#ifdef HAVE_STDIO_H
++# include <stdio.h>
+ #endif
+-#ifdef HAVE_SYS_STAT_H
+-# include <sys/stat.h>
+-#endif
+-#ifdef STDC_HEADERS
++#ifdef HAVE_STDLIB_H
+ # include <stdlib.h>
+-# include <stddef.h>
+-#else
+-# ifdef HAVE_STDLIB_H
+-#  include <stdlib.h>
+-# endif
+ #endif
+ #ifdef HAVE_STRING_H
+-# if !defined STDC_HEADERS && defined HAVE_MEMORY_H
+-#  include <memory.h>
+-# endif
+ # include <string.h>
+ #endif
+-#ifdef HAVE_STRINGS_H
+-# include <strings.h>
+-#endif
+ #ifdef HAVE_INTTYPES_H
+ # include <inttypes.h>
+ #endif
+@@ -618,10 +635,20 @@
+ #ifdef HAVE_STDINT_H
+ # include <stdint.h>
+ #endif
++#ifdef HAVE_STRINGS_H
++# include <strings.h>
++#endif
++#ifdef HAVE_SYS_TYPES_H
++# include <sys/types.h>
++#endif
++#ifdef HAVE_SYS_STAT_H
++# include <sys/stat.h>
++#endif
+ #ifdef HAVE_UNISTD_H
+ # include <unistd.h>
+ #endif"
+ 
++ac_header_cxx_list=
+ ac_subst_vars='LTLIBOBJS
+ LIBOBJS
+ PROCESSOR_DEFINE
+@@ -637,9 +664,6 @@
+ OMNINAMES_LOGDIR
+ OMNIORB_CONFIG
+ ALLOCA
+-EGREP
+-GREP
+-CXXCPP
+ OPEN_SSL_LIB
+ OPEN_SSL_CPPFLAGS
+ OPEN_SSL_ROOT
+@@ -656,9 +680,9 @@
+ pyexecdir
+ pkgpythondir
+ pythondir
+-PYTHON_PLATFORM
+ PYTHON_EXEC_PREFIX
+ PYTHON_PREFIX
++PYTHON_PLATFORM
+ PYTHON_VERSION
+ PYTHON
+ SET_MAKE
+@@ -727,6 +751,9 @@
+ ac_subst_files=''
+ ac_user_opts='
+ enable_option_checking
++with_python_sys_prefix
++with_python_prefix
++with_python_exec_prefix
+ with_openssl
+ with_omniORB_config
+ with_omniNames_logdir
+@@ -755,8 +782,7 @@
+ PKG_CONFIG_PATH
+ PKG_CONFIG_LIBDIR
+ OPENSSL_CFLAGS
+-OPENSSL_LIBS
+-CXXCPP'
++OPENSSL_LIBS'
+ 
+ 
+ # Initialize some variables set by options.
+@@ -825,8 +851,6 @@
+   *)    ac_optarg=yes ;;
+   esac
+ 
+-  # Accept the important Cygnus configure options, so we can diagnose typos.
+-
+   case $ac_dashdash$ac_option in
+   --)
+     ac_dashdash=yes ;;
+@@ -867,9 +891,9 @@
+     ac_useropt=`expr "x$ac_option" : 'x-*disable-\(.*\)'`
+     # Reject names that are not valid shell variable names.
+     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
+-      as_fn_error $? "invalid feature name: $ac_useropt"
++      as_fn_error $? "invalid feature name: \`$ac_useropt'"
+     ac_useropt_orig=$ac_useropt
+-    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
++    ac_useropt=`printf "%s\n" "$ac_useropt" | sed 's/[-+.]/_/g'`
+     case $ac_user_opts in
+       *"
+ "enable_$ac_useropt"
+@@ -893,9 +917,9 @@
+     ac_useropt=`expr "x$ac_option" : 'x-*enable-\([^=]*\)'`
+     # Reject names that are not valid shell variable names.
+     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
+-      as_fn_error $? "invalid feature name: $ac_useropt"
++      as_fn_error $? "invalid feature name: \`$ac_useropt'"
+     ac_useropt_orig=$ac_useropt
+-    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
++    ac_useropt=`printf "%s\n" "$ac_useropt" | sed 's/[-+.]/_/g'`
+     case $ac_user_opts in
+       *"
+ "enable_$ac_useropt"
+@@ -1106,9 +1130,9 @@
+     ac_useropt=`expr "x$ac_option" : 'x-*with-\([^=]*\)'`
+     # Reject names that are not valid shell variable names.
+     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
+-      as_fn_error $? "invalid package name: $ac_useropt"
++      as_fn_error $? "invalid package name: \`$ac_useropt'"
+     ac_useropt_orig=$ac_useropt
+-    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
++    ac_useropt=`printf "%s\n" "$ac_useropt" | sed 's/[-+.]/_/g'`
+     case $ac_user_opts in
+       *"
+ "with_$ac_useropt"
+@@ -1122,9 +1146,9 @@
+     ac_useropt=`expr "x$ac_option" : 'x-*without-\(.*\)'`
+     # Reject names that are not valid shell variable names.
+     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
+-      as_fn_error $? "invalid package name: $ac_useropt"
++      as_fn_error $? "invalid package name: \`$ac_useropt'"
+     ac_useropt_orig=$ac_useropt
+-    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
++    ac_useropt=`printf "%s\n" "$ac_useropt" | sed 's/[-+.]/_/g'`
+     case $ac_user_opts in
+       *"
+ "with_$ac_useropt"
+@@ -1168,9 +1192,9 @@
+ 
+   *)
+     # FIXME: should be removed in autoconf 3.0.
+-    $as_echo "$as_me: WARNING: you should use --build, --host, --target" >&2
++    printf "%s\n" "$as_me: WARNING: you should use --build, --host, --target" >&2
+     expr "x$ac_option" : ".*[^-._$as_cr_alnum]" >/dev/null &&
+-      $as_echo "$as_me: WARNING: invalid host type: $ac_option" >&2
++      printf "%s\n" "$as_me: WARNING: invalid host type: $ac_option" >&2
+     : "${build_alias=$ac_option} ${host_alias=$ac_option} ${target_alias=$ac_option}"
+     ;;
+ 
+@@ -1186,7 +1210,7 @@
+   case $enable_option_checking in
+     no) ;;
+     fatal) as_fn_error $? "unrecognized options: $ac_unrecognized_opts" ;;
+-    *)     $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2 ;;
++    *)     printf "%s\n" "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2 ;;
+   esac
+ fi
+ 
+@@ -1250,7 +1274,7 @@
+ 	 X"$as_myself" : 'X\(//\)[^/]' \| \
+ 	 X"$as_myself" : 'X\(//\)$' \| \
+ 	 X"$as_myself" : 'X\(/\)' \| . 2>/dev/null ||
+-$as_echo X"$as_myself" |
++printf "%s\n" X"$as_myself" |
+     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
+ 	    s//\1/
+ 	    q
+@@ -1397,6 +1421,11 @@
+ Optional Packages:
+   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
++  --with-python-sys-prefix
++                          use Python's sys.prefix and sys.exec_prefix values
++  --with-python_prefix    override the default PYTHON_PREFIX
++  --with-python_exec_prefix
++                          override the default PYTHON_EXEC_PREFIX
+   --with-openssl          OpenSSL root directory (default none)
+   --with-omniORB-config   location of omniORB config file (default
+                           /etc/omniORB.cfg)
+@@ -1424,7 +1453,6 @@
+               C compiler flags for OPENSSL, overriding pkg-config
+   OPENSSL_LIBS
+               linker flags for OPENSSL, overriding pkg-config
+-  CXXCPP      C++ preprocessor
+ 
+ Use these variables to override the choices made by `configure' or to help
+ it to find libraries and programs with nonstandard names/locations.
+@@ -1445,9 +1473,9 @@
+ case "$ac_dir" in
+ .) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
+ *)
+-  ac_dir_suffix=/`$as_echo "$ac_dir" | sed 's|^\.[\\/]||'`
++  ac_dir_suffix=/`printf "%s\n" "$ac_dir" | sed 's|^\.[\\/]||'`
+   # A ".." for each directory in $ac_dir_suffix.
+-  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
++  ac_top_builddir_sub=`printf "%s\n" "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+   case $ac_top_builddir_sub in
+   "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
+   *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
+@@ -1475,7 +1503,8 @@
+ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
+ 
+     cd "$ac_dir" || { ac_status=$?; continue; }
+-    # Check for guested configure.
++    # Check for configure.gnu first; this name is used for a wrapper for
++    # Metaconfig's "Configure" on case-insensitive file systems.
+     if test -f "$ac_srcdir/configure.gnu"; then
+       echo &&
+       $SHELL "$ac_srcdir/configure.gnu" --help=recursive
+@@ -1483,7 +1512,7 @@
+       echo &&
+       $SHELL "$ac_srcdir/configure" --help=recursive
+     else
+-      $as_echo "$as_me: WARNING: no configuration information is in $ac_dir" >&2
++      printf "%s\n" "$as_me: WARNING: no configuration information is in $ac_dir" >&2
+     fi || ac_status=$?
+     cd "$ac_pwd" || { ac_status=$?; break; }
+   done
+@@ -1493,9 +1522,9 @@
+ if $ac_init_version; then
+   cat <<\_ACEOF
+ omniORB configure 4.2.5
+-generated by GNU Autoconf 2.69
++generated by GNU Autoconf 2.71
+ 
+-Copyright (C) 2012 Free Software Foundation, Inc.
++Copyright (C) 2021 Free Software Foundation, Inc.
+ This configure script is free software; the Free Software Foundation
+ gives unlimited permission to copy, distribute and modify it.
+ _ACEOF
+@@ -1512,7 +1541,7 @@
+ ac_fn_c_try_compile ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  rm -f conftest.$ac_objext
++  rm -f conftest.$ac_objext conftest.beam
+   if { { ac_try="$ac_compile"
+ case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -1519,7 +1548,7 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_compile") 2>conftest.err
+   ac_status=$?
+   if test -s conftest.err; then
+@@ -1527,14 +1556,15 @@
+     cat conftest.er1 >&5
+     mv -f conftest.er1 conftest.err
+   fi
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } && {
+ 	 test -z "$ac_c_werror_flag" ||
+ 	 test ! -s conftest.err
+-       } && test -s conftest.$ac_objext; then :
++       } && test -s conftest.$ac_objext
++then :
+   ac_retval=0
+-else
+-  $as_echo "$as_me: failed program was:" >&5
++else $as_nop
++  printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+ 	ac_retval=1
+@@ -1550,7 +1580,7 @@
+ ac_fn_cxx_try_compile ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  rm -f conftest.$ac_objext
++  rm -f conftest.$ac_objext conftest.beam
+   if { { ac_try="$ac_compile"
+ case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -1557,7 +1587,7 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_compile") 2>conftest.err
+   ac_status=$?
+   if test -s conftest.err; then
+@@ -1565,14 +1595,15 @@
+     cat conftest.er1 >&5
+     mv -f conftest.er1 conftest.err
+   fi
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } && {
+ 	 test -z "$ac_cxx_werror_flag" ||
+ 	 test ! -s conftest.err
+-       } && test -s conftest.$ac_objext; then :
++       } && test -s conftest.$ac_objext
++then :
+   ac_retval=0
+-else
+-  $as_echo "$as_me: failed program was:" >&5
++else $as_nop
++  printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+ 	ac_retval=1
+@@ -1594,7 +1625,7 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_cpp conftest.$ac_ext") 2>conftest.err
+   ac_status=$?
+   if test -s conftest.err; then
+@@ -1602,14 +1633,15 @@
+     cat conftest.er1 >&5
+     mv -f conftest.er1 conftest.err
+   fi
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } > conftest.i && {
+ 	 test -z "$ac_c_preproc_warn_flag$ac_c_werror_flag" ||
+ 	 test ! -s conftest.err
+-       }; then :
++       }
++then :
+   ac_retval=0
+-else
+-  $as_echo "$as_me: failed program was:" >&5
++else $as_nop
++  printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+     ac_retval=1
+@@ -1619,138 +1651,43 @@
+ 
+ } # ac_fn_c_try_cpp
+ 
+-# ac_fn_cxx_try_cpp LINENO
+-# ------------------------
+-# Try to preprocess conftest.$ac_ext, and return whether this succeeded.
+-ac_fn_cxx_try_cpp ()
+-{
+-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  if { { ac_try="$ac_cpp conftest.$ac_ext"
+-case "(($ac_try" in
+-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+-  *) ac_try_echo=$ac_try;;
+-esac
+-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
+-  (eval "$ac_cpp conftest.$ac_ext") 2>conftest.err
+-  ac_status=$?
+-  if test -s conftest.err; then
+-    grep -v '^ *+' conftest.err >conftest.er1
+-    cat conftest.er1 >&5
+-    mv -f conftest.er1 conftest.err
+-  fi
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; } > conftest.i && {
+-	 test -z "$ac_cxx_preproc_warn_flag$ac_cxx_werror_flag" ||
+-	 test ! -s conftest.err
+-       }; then :
+-  ac_retval=0
+-else
+-  $as_echo "$as_me: failed program was:" >&5
+-sed 's/^/| /' conftest.$ac_ext >&5
+-
+-    ac_retval=1
+-fi
+-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+-  as_fn_set_status $ac_retval
+-
+-} # ac_fn_cxx_try_cpp
+-
+-# ac_fn_cxx_check_header_mongrel LINENO HEADER VAR INCLUDES
++# ac_fn_cxx_check_header_compile LINENO HEADER VAR INCLUDES
+ # ---------------------------------------------------------
+-# Tests whether HEADER exists, giving a warning if it cannot be compiled using
+-# the include files in INCLUDES and setting the cache variable VAR
+-# accordingly.
+-ac_fn_cxx_check_header_mongrel ()
++# Tests whether HEADER exists and can be compiled using the include files in
++# INCLUDES, setting the cache variable VAR accordingly.
++ac_fn_cxx_check_header_compile ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  if eval \${$3+:} false; then :
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+-$as_echo_n "checking for $2... " >&6; }
+-if eval \${$3+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-fi
+-eval ac_res=\$$3
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
+-else
+-  # Is the header compilable?
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking $2 usability" >&5
+-$as_echo_n "checking $2 usability... " >&6; }
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
++printf %s "checking for $2... " >&6; }
++if eval test \${$3+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $4
+ #include <$2>
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
+-  ac_header_compiler=yes
+-else
+-  ac_header_compiler=no
++if ac_fn_cxx_try_compile "$LINENO"
++then :
++  eval "$3=yes"
++else $as_nop
++  eval "$3=no"
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_header_compiler" >&5
+-$as_echo "$ac_header_compiler" >&6; }
+-
+-# Is the header present?
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking $2 presence" >&5
+-$as_echo_n "checking $2 presence... " >&6; }
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <$2>
+-_ACEOF
+-if ac_fn_cxx_try_cpp "$LINENO"; then :
+-  ac_header_preproc=yes
+-else
+-  ac_header_preproc=no
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f conftest.err conftest.i conftest.$ac_ext
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_header_preproc" >&5
+-$as_echo "$ac_header_preproc" >&6; }
+-
+-# So?  What about this header?
+-case $ac_header_compiler:$ac_header_preproc:$ac_cxx_preproc_warn_flag in #((
+-  yes:no: )
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: accepted by the compiler, rejected by the preprocessor!" >&5
+-$as_echo "$as_me: WARNING: $2: accepted by the compiler, rejected by the preprocessor!" >&2;}
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: proceeding with the compiler's result" >&5
+-$as_echo "$as_me: WARNING: $2: proceeding with the compiler's result" >&2;}
+-    ;;
+-  no:yes:* )
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: present but cannot be compiled" >&5
+-$as_echo "$as_me: WARNING: $2: present but cannot be compiled" >&2;}
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2:     check for missing prerequisite headers?" >&5
+-$as_echo "$as_me: WARNING: $2:     check for missing prerequisite headers?" >&2;}
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: see the Autoconf documentation" >&5
+-$as_echo "$as_me: WARNING: $2: see the Autoconf documentation" >&2;}
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2:     section \"Present But Cannot Be Compiled\"" >&5
+-$as_echo "$as_me: WARNING: $2:     section \"Present But Cannot Be Compiled\"" >&2;}
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: proceeding with the compiler's result" >&5
+-$as_echo "$as_me: WARNING: $2: proceeding with the compiler's result" >&2;}
+-( $as_echo "## --------------------------------------- ##
+-## Report this to bugs@omniorb-support.com ##
+-## --------------------------------------- ##"
+-     ) | sed "s/^/$as_me: WARNING:     /" >&2
+-    ;;
+-esac
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+-$as_echo_n "checking for $2... " >&6; }
+-if eval \${$3+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  eval "$3=\$ac_header_compiler"
+-fi
+ eval ac_res=\$$3
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
+-fi
++	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
++printf "%s\n" "$ac_res" >&6; }
+   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+ 
+-} # ac_fn_cxx_check_header_mongrel
++} # ac_fn_cxx_check_header_compile
+ 
+ # ac_fn_cxx_try_run LINENO
+ # ------------------------
+-# Try to link conftest.$ac_ext, and return whether this succeeded. Assumes
+-# that executables *can* be run.
++# Try to run conftest.$ac_ext, and return whether this succeeded. Assumes that
++# executables *can* be run.
+ ac_fn_cxx_try_run ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+@@ -1760,10 +1697,10 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_link") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } && { ac_try='./conftest$ac_exeext'
+   { { case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -1770,15 +1707,16 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_try") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; }; then :
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; }
++then :
+   ac_retval=0
+-else
+-  $as_echo "$as_me: program exited with status $ac_status" >&5
+-       $as_echo "$as_me: failed program was:" >&5
++else $as_nop
++  printf "%s\n" "$as_me: program exited with status $ac_status" >&5
++       printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+        ac_retval=$ac_status
+@@ -1789,37 +1727,6 @@
+ 
+ } # ac_fn_cxx_try_run
+ 
+-# ac_fn_cxx_check_header_compile LINENO HEADER VAR INCLUDES
+-# ---------------------------------------------------------
+-# Tests whether HEADER exists and can be compiled using the include files in
+-# INCLUDES, setting the cache variable VAR accordingly.
+-ac_fn_cxx_check_header_compile ()
+-{
+-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+-$as_echo_n "checking for $2... " >&6; }
+-if eval \${$3+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-$4
+-#include <$2>
+-_ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
+-  eval "$3=yes"
+-else
+-  eval "$3=no"
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-fi
+-eval ac_res=\$$3
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
+-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+-
+-} # ac_fn_cxx_check_header_compile
+-
+ # ac_fn_cxx_compute_int LINENO EXPR VAR INCLUDES
+ # ----------------------------------------------
+ # Tries to find the compile-time value of EXPR in a program that includes
+@@ -1834,7 +1741,7 @@
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ static int test_array [1 - 2 * !(($2) >= 0)];
+ test_array [0] = 0;
+@@ -1844,7 +1751,8 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_lo=0 ac_mid=0
+   while :; do
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -1851,7 +1759,7 @@
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ static int test_array [1 - 2 * !(($2) <= $ac_mid)];
+ test_array [0] = 0;
+@@ -1861,9 +1769,10 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_hi=$ac_mid; break
+-else
++else $as_nop
+   as_fn_arith $ac_mid + 1 && ac_lo=$as_val
+ 			if test $ac_lo -le $ac_mid; then
+ 			  ac_lo= ac_hi=
+@@ -1871,14 +1780,14 @@
+ 			fi
+ 			as_fn_arith 2 '*' $ac_mid + 1 && ac_mid=$as_val
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+   done
+-else
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ static int test_array [1 - 2 * !(($2) < 0)];
+ test_array [0] = 0;
+@@ -1888,7 +1797,8 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_hi=-1 ac_mid=-1
+   while :; do
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -1895,7 +1805,7 @@
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ static int test_array [1 - 2 * !(($2) >= $ac_mid)];
+ test_array [0] = 0;
+@@ -1905,9 +1815,10 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_lo=$ac_mid; break
+-else
++else $as_nop
+   as_fn_arith '(' $ac_mid ')' - 1 && ac_hi=$as_val
+ 			if test $ac_mid -le $ac_hi; then
+ 			  ac_lo= ac_hi=
+@@ -1915,14 +1826,14 @@
+ 			fi
+ 			as_fn_arith 2 '*' $ac_mid && ac_mid=$as_val
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+   done
+-else
++else $as_nop
+   ac_lo= ac_hi=
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ # Binary search between lo and hi bounds.
+ while test "x$ac_lo" != "x$ac_hi"; do
+   as_fn_arith '(' $ac_hi - $ac_lo ')' / 2 + $ac_lo && ac_mid=$as_val
+@@ -1930,7 +1841,7 @@
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ static int test_array [1 - 2 * !(($2) <= $ac_mid)];
+ test_array [0] = 0;
+@@ -1940,12 +1851,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_hi=$ac_mid
+-else
++else $as_nop
+   as_fn_arith '(' $ac_mid ')' + 1 && ac_lo=$as_val
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ done
+ case $ac_lo in #((
+ ?*) eval "$3=\$ac_lo"; ac_retval=0 ;;
+@@ -1955,12 +1867,12 @@
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $4
+-static long int longval () { return $2; }
+-static unsigned long int ulongval () { return $2; }
++static long int longval (void) { return $2; }
++static unsigned long int ulongval (void) { return $2; }
+ #include <stdio.h>
+ #include <stdlib.h>
+ int
+-main ()
++main (void)
+ {
+ 
+   FILE *f = fopen ("conftest.val", "w");
+@@ -1988,9 +1900,10 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_run "$LINENO"; then :
++if ac_fn_cxx_try_run "$LINENO"
++then :
+   echo >>conftest.val; read $3 <conftest.val; ac_retval=0
+-else
++else $as_nop
+   ac_retval=1
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+@@ -2010,17 +1923,18 @@
+ ac_fn_cxx_check_type ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+-$as_echo_n "checking for $2... " >&6; }
+-if eval \${$3+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
++printf %s "checking for $2... " >&6; }
++if eval test \${$3+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   eval "$3=no"
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ if (sizeof ($2))
+ 	 return 0;
+@@ -2028,12 +1942,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ if (sizeof (($2)))
+ 	    return 0;
+@@ -2041,18 +1956,19 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+ 
+-else
++else $as_nop
+   eval "$3=yes"
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+ eval ac_res=\$$3
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
++	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
++printf "%s\n" "$ac_res" >&6; }
+   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+ 
+ } # ac_fn_cxx_check_type
+@@ -2064,16 +1980,17 @@
+ ac_fn_cxx_check_member ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2.$3" >&5
+-$as_echo_n "checking for $2.$3... " >&6; }
+-if eval \${$4+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2.$3" >&5
++printf %s "checking for $2.$3... " >&6; }
++if eval test \${$4+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $5
+ int
+-main ()
++main (void)
+ {
+ static $2 ac_aggr;
+ if (ac_aggr.$3)
+@@ -2082,14 +1999,15 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   eval "$4=yes"
+-else
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $5
+ int
+-main ()
++main (void)
+ {
+ static $2 ac_aggr;
+ if (sizeof ac_aggr.$3)
+@@ -2098,18 +2016,19 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   eval "$4=yes"
+-else
++else $as_nop
+   eval "$4=no"
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+ eval ac_res=\$$4
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
++	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
++printf "%s\n" "$ac_res" >&6; }
+   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+ 
+ } # ac_fn_cxx_check_member
+@@ -2120,7 +2039,7 @@
+ ac_fn_cxx_try_link ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  rm -f conftest.$ac_objext conftest$ac_exeext
++  rm -f conftest.$ac_objext conftest.beam conftest$ac_exeext
+   if { { ac_try="$ac_link"
+ case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -2127,7 +2046,7 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_link") 2>conftest.err
+   ac_status=$?
+   if test -s conftest.err; then
+@@ -2135,7 +2054,7 @@
+     cat conftest.er1 >&5
+     mv -f conftest.er1 conftest.err
+   fi
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } && {
+ 	 test -z "$ac_cxx_werror_flag" ||
+ 	 test ! -s conftest.err
+@@ -2142,10 +2061,11 @@
+        } && test -s conftest$ac_exeext && {
+ 	 test "$cross_compiling" = yes ||
+ 	 test -x conftest$ac_exeext
+-       }; then :
++       }
++then :
+   ac_retval=0
+-else
+-  $as_echo "$as_me: failed program was:" >&5
++else $as_nop
++  printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+ 	ac_retval=1
+@@ -2166,7 +2086,7 @@
+ ac_fn_c_try_link ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  rm -f conftest.$ac_objext conftest$ac_exeext
++  rm -f conftest.$ac_objext conftest.beam conftest$ac_exeext
+   if { { ac_try="$ac_link"
+ case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -2173,7 +2093,7 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_link") 2>conftest.err
+   ac_status=$?
+   if test -s conftest.err; then
+@@ -2181,7 +2101,7 @@
+     cat conftest.er1 >&5
+     mv -f conftest.er1 conftest.err
+   fi
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } && {
+ 	 test -z "$ac_c_werror_flag" ||
+ 	 test ! -s conftest.err
+@@ -2188,10 +2108,11 @@
+        } && test -s conftest$ac_exeext && {
+ 	 test "$cross_compiling" = yes ||
+ 	 test -x conftest$ac_exeext
+-       }; then :
++       }
++then :
+   ac_retval=0
+-else
+-  $as_echo "$as_me: failed program was:" >&5
++else $as_nop
++  printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+ 	ac_retval=1
+@@ -2212,11 +2133,12 @@
+ ac_fn_c_check_func ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+-$as_echo_n "checking for $2... " >&6; }
+-if eval \${$3+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
++printf %s "checking for $2... " >&6; }
++if eval test \${$3+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ /* Define $2 to an innocuous variant, in case <limits.h> declares $2.
+@@ -2224,16 +2146,9 @@
+ #define $2 innocuous_$2
+ 
+ /* System header to define __stub macros and hopefully few prototypes,
+-    which can conflict with char $2 (); below.
+-    Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+-    <limits.h> exists even on freestanding compilers.  */
++   which can conflict with char $2 (); below.  */
+ 
+-#ifdef __STDC__
+-# include <limits.h>
+-#else
+-# include <assert.h>
+-#endif
+-
++#include <limits.h>
+ #undef $2
+ 
+ /* Override any GCC internal prototype to avoid an error.
+@@ -2251,7 +2166,7 @@
+ #endif
+ 
+ int
+-main ()
++main (void)
+ {
+ return $2 ();
+   ;
+@@ -2258,17 +2173,18 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_link "$LINENO"; then :
++if ac_fn_c_try_link "$LINENO"
++then :
+   eval "$3=yes"
+-else
++else $as_nop
+   eval "$3=no"
+ fi
+-rm -f core conftest.err conftest.$ac_objext \
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ fi
+ eval ac_res=\$$3
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
++	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
++printf "%s\n" "$ac_res" >&6; }
+   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+ 
+ } # ac_fn_c_check_func
+@@ -2280,17 +2196,18 @@
+ ac_fn_c_check_type ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+-$as_echo_n "checking for $2... " >&6; }
+-if eval \${$3+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
++printf %s "checking for $2... " >&6; }
++if eval test \${$3+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   eval "$3=no"
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ if (sizeof ($2))
+ 	 return 0;
+@@ -2298,12 +2215,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
++if ac_fn_c_try_compile "$LINENO"
++then :
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $4
+ int
+-main ()
++main (void)
+ {
+ if (sizeof (($2)))
+ 	    return 0;
+@@ -2311,18 +2229,19 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
++if ac_fn_c_try_compile "$LINENO"
++then :
+ 
+-else
++else $as_nop
+   eval "$3=yes"
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+ eval ac_res=\$$3
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
++	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
++printf "%s\n" "$ac_res" >&6; }
+   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+ 
+ } # ac_fn_c_check_type
+@@ -2329,8 +2248,8 @@
+ 
+ # ac_fn_c_try_run LINENO
+ # ----------------------
+-# Try to link conftest.$ac_ext, and return whether this succeeded. Assumes
+-# that executables *can* be run.
++# Try to run conftest.$ac_ext, and return whether this succeeded. Assumes that
++# executables *can* be run.
+ ac_fn_c_try_run ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+@@ -2340,10 +2259,10 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_link") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } && { ac_try='./conftest$ac_exeext'
+   { { case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -2350,15 +2269,16 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_try") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; }; then :
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; }
++then :
+   ac_retval=0
+-else
+-  $as_echo "$as_me: program exited with status $ac_status" >&5
+-       $as_echo "$as_me: failed program was:" >&5
++else $as_nop
++  printf "%s\n" "$as_me: program exited with status $ac_status" >&5
++       printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+        ac_retval=$ac_status
+@@ -2368,14 +2288,34 @@
+   as_fn_set_status $ac_retval
+ 
+ } # ac_fn_c_try_run
++ac_configure_args_raw=
++for ac_arg
++do
++  case $ac_arg in
++  *\'*)
++    ac_arg=`printf "%s\n" "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
++  esac
++  as_fn_append ac_configure_args_raw " '$ac_arg'"
++done
++
++case $ac_configure_args_raw in
++  *$as_nl*)
++    ac_safe_unquote= ;;
++  *)
++    ac_unsafe_z='|&;<>()$`\\"*?[ ''	' # This string ends in space, tab.
++    ac_unsafe_a="$ac_unsafe_z#~"
++    ac_safe_unquote="s/ '\\([^$ac_unsafe_a][^$ac_unsafe_z]*\\)'/ \\1/g"
++    ac_configure_args_raw=`      printf "%s\n" "$ac_configure_args_raw" | sed "$ac_safe_unquote"`;;
++esac
++
+ cat >config.log <<_ACEOF
+ This file contains any messages produced by compilers while
+ running configure, to aid debugging if configure makes a mistake.
+ 
+ It was created by omniORB $as_me 4.2.5, which was
+-generated by GNU Autoconf 2.69.  Invocation command line was
++generated by GNU Autoconf 2.71.  Invocation command line was
+ 
+-  $ $0 $@
++  $ $0$ac_configure_args_raw
+ 
+ _ACEOF
+ exec 5>>config.log
+@@ -2408,8 +2348,12 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    $as_echo "PATH: $as_dir"
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    printf "%s\n" "PATH: $as_dir"
+   done
+ IFS=$as_save_IFS
+ 
+@@ -2444,7 +2388,7 @@
+     | -silent | --silent | --silen | --sile | --sil)
+       continue ;;
+     *\'*)
+-      ac_arg=`$as_echo "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
++      ac_arg=`printf "%s\n" "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
+     esac
+     case $ac_pass in
+     1) as_fn_append ac_configure_args0 " '$ac_arg'" ;;
+@@ -2479,11 +2423,13 @@
+ # WARNING: Use '\'' to represent an apostrophe within the trap.
+ # WARNING: Do not start the trap code with a newline, due to a FreeBSD 4.0 bug.
+ trap 'exit_status=$?
++  # Sanitize IFS.
++  IFS=" ""	$as_nl"
+   # Save into config.log some information that might help in debugging.
+   {
+     echo
+ 
+-    $as_echo "## ---------------- ##
++    printf "%s\n" "## ---------------- ##
+ ## Cache variables. ##
+ ## ---------------- ##"
+     echo
+@@ -2494,8 +2440,8 @@
+     case $ac_val in #(
+     *${as_nl}*)
+       case $ac_var in #(
+-      *_cv_*) { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
+-$as_echo "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
++      *_cv_*) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
++printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
+       esac
+       case $ac_var in #(
+       _ | IFS | as_nl) ;; #(
+@@ -2519,7 +2465,7 @@
+ )
+     echo
+ 
+-    $as_echo "## ----------------- ##
++    printf "%s\n" "## ----------------- ##
+ ## Output variables. ##
+ ## ----------------- ##"
+     echo
+@@ -2527,14 +2473,14 @@
+     do
+       eval ac_val=\$$ac_var
+       case $ac_val in
+-      *\'\''*) ac_val=`$as_echo "$ac_val" | sed "s/'\''/'\''\\\\\\\\'\'''\''/g"`;;
++      *\'\''*) ac_val=`printf "%s\n" "$ac_val" | sed "s/'\''/'\''\\\\\\\\'\'''\''/g"`;;
+       esac
+-      $as_echo "$ac_var='\''$ac_val'\''"
++      printf "%s\n" "$ac_var='\''$ac_val'\''"
+     done | sort
+     echo
+ 
+     if test -n "$ac_subst_files"; then
+-      $as_echo "## ------------------- ##
++      printf "%s\n" "## ------------------- ##
+ ## File substitutions. ##
+ ## ------------------- ##"
+       echo
+@@ -2542,15 +2488,15 @@
+       do
+ 	eval ac_val=\$$ac_var
+ 	case $ac_val in
+-	*\'\''*) ac_val=`$as_echo "$ac_val" | sed "s/'\''/'\''\\\\\\\\'\'''\''/g"`;;
++	*\'\''*) ac_val=`printf "%s\n" "$ac_val" | sed "s/'\''/'\''\\\\\\\\'\'''\''/g"`;;
+ 	esac
+-	$as_echo "$ac_var='\''$ac_val'\''"
++	printf "%s\n" "$ac_var='\''$ac_val'\''"
+       done | sort
+       echo
+     fi
+ 
+     if test -s confdefs.h; then
+-      $as_echo "## ----------- ##
++      printf "%s\n" "## ----------- ##
+ ## confdefs.h. ##
+ ## ----------- ##"
+       echo
+@@ -2558,8 +2504,8 @@
+       echo
+     fi
+     test "$ac_signal" != 0 &&
+-      $as_echo "$as_me: caught signal $ac_signal"
+-    $as_echo "$as_me: exit $exit_status"
++      printf "%s\n" "$as_me: caught signal $ac_signal"
++    printf "%s\n" "$as_me: exit $exit_status"
+   } >&5
+   rm -f core *.core core.conftest.* &&
+     rm -f -r conftest* confdefs* conf$$* $ac_clean_files &&
+@@ -2573,63 +2519,48 @@
+ # confdefs.h avoids OS command line length limits that DEFS can exceed.
+ rm -f -r conftest* confdefs.h
+ 
+-$as_echo "/* confdefs.h */" > confdefs.h
++printf "%s\n" "/* confdefs.h */" > confdefs.h
+ 
+ # Predefined preprocessor variables.
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define PACKAGE_NAME "$PACKAGE_NAME"
+-_ACEOF
++printf "%s\n" "#define PACKAGE_NAME \"$PACKAGE_NAME\"" >>confdefs.h
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define PACKAGE_TARNAME "$PACKAGE_TARNAME"
+-_ACEOF
++printf "%s\n" "#define PACKAGE_TARNAME \"$PACKAGE_TARNAME\"" >>confdefs.h
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define PACKAGE_VERSION "$PACKAGE_VERSION"
+-_ACEOF
++printf "%s\n" "#define PACKAGE_VERSION \"$PACKAGE_VERSION\"" >>confdefs.h
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define PACKAGE_STRING "$PACKAGE_STRING"
+-_ACEOF
++printf "%s\n" "#define PACKAGE_STRING \"$PACKAGE_STRING\"" >>confdefs.h
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define PACKAGE_BUGREPORT "$PACKAGE_BUGREPORT"
+-_ACEOF
++printf "%s\n" "#define PACKAGE_BUGREPORT \"$PACKAGE_BUGREPORT\"" >>confdefs.h
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define PACKAGE_URL "$PACKAGE_URL"
+-_ACEOF
++printf "%s\n" "#define PACKAGE_URL \"$PACKAGE_URL\"" >>confdefs.h
+ 
+ 
+ # Let the site file select an alternate cache file if it wants to.
+ # Prefer an explicitly selected file to automatically selected ones.
+-ac_site_file1=NONE
+-ac_site_file2=NONE
+ if test -n "$CONFIG_SITE"; then
+-  # We do not want a PATH search for config.site.
+-  case $CONFIG_SITE in #((
+-    -*)  ac_site_file1=./$CONFIG_SITE;;
+-    */*) ac_site_file1=$CONFIG_SITE;;
+-    *)   ac_site_file1=./$CONFIG_SITE;;
+-  esac
++  ac_site_files="$CONFIG_SITE"
+ elif test "x$prefix" != xNONE; then
+-  ac_site_file1=$prefix/share/config.site
+-  ac_site_file2=$prefix/etc/config.site
++  ac_site_files="$prefix/share/config.site $prefix/etc/config.site"
+ else
+-  ac_site_file1=$ac_default_prefix/share/config.site
+-  ac_site_file2=$ac_default_prefix/etc/config.site
++  ac_site_files="$ac_default_prefix/share/config.site $ac_default_prefix/etc/config.site"
+ fi
+-for ac_site_file in "$ac_site_file1" "$ac_site_file2"
++
++for ac_site_file in $ac_site_files
+ do
+-  test "x$ac_site_file" = xNONE && continue
+-  if test /dev/null != "$ac_site_file" && test -r "$ac_site_file"; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: loading site script $ac_site_file" >&5
+-$as_echo "$as_me: loading site script $ac_site_file" >&6;}
++  case $ac_site_file in #(
++  */*) :
++     ;; #(
++  *) :
++    ac_site_file=./$ac_site_file ;;
++esac
++  if test -f "$ac_site_file" && test -r "$ac_site_file"; then
++    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: loading site script $ac_site_file" >&5
++printf "%s\n" "$as_me: loading site script $ac_site_file" >&6;}
+     sed 's/^/| /' "$ac_site_file" >&5
+     . "$ac_site_file" \
+-      || { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++      || { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error $? "failed to load site script $ac_site_file
+ See \`config.log' for more details" "$LINENO" 5; }
+   fi
+@@ -2639,8 +2570,8 @@
+   # Some versions of bash will fail to source /dev/null (special files
+   # actually), so we avoid doing that.  DJGPP emulates it as a regular file.
+   if test /dev/null != "$cache_file" && test -f "$cache_file"; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: loading cache $cache_file" >&5
+-$as_echo "$as_me: loading cache $cache_file" >&6;}
++    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: loading cache $cache_file" >&5
++printf "%s\n" "$as_me: loading cache $cache_file" >&6;}
+     case $cache_file in
+       [\\/]* | ?:[\\/]* ) . "$cache_file";;
+       *)                      . "./$cache_file";;
+@@ -2647,11 +2578,642 @@
+     esac
+   fi
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: creating cache $cache_file" >&5
+-$as_echo "$as_me: creating cache $cache_file" >&6;}
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: creating cache $cache_file" >&5
++printf "%s\n" "$as_me: creating cache $cache_file" >&6;}
+   >$cache_file
+ fi
+ 
++# Test code for whether the C compiler supports C89 (global declarations)
++ac_c_conftest_c89_globals='
++/* Does the compiler advertise C89 conformance?
++   Do not test the value of __STDC__, because some compilers set it to 0
++   while being otherwise adequately conformant. */
++#if !defined __STDC__
++# error "Compiler does not advertise C89 conformance"
++#endif
++
++#include <stddef.h>
++#include <stdarg.h>
++struct stat;
++/* Most of the following tests are stolen from RCS 5.7 src/conf.sh.  */
++struct buf { int x; };
++struct buf * (*rcsopen) (struct buf *, struct stat *, int);
++static char *e (p, i)
++     char **p;
++     int i;
++{
++  return p[i];
++}
++static char *f (char * (*g) (char **, int), char **p, ...)
++{
++  char *s;
++  va_list v;
++  va_start (v,p);
++  s = g (p, va_arg (v,int));
++  va_end (v);
++  return s;
++}
++
++/* OSF 4.0 Compaq cc is some sort of almost-ANSI by default.  It has
++   function prototypes and stuff, but not \xHH hex character constants.
++   These do not provoke an error unfortunately, instead are silently treated
++   as an "x".  The following induces an error, until -std is added to get
++   proper ANSI mode.  Curiously \x00 != x always comes out true, for an
++   array size at least.  It is necessary to write \x00 == 0 to get something
++   that is true only with -std.  */
++int osf4_cc_array ['\''\x00'\'' == 0 ? 1 : -1];
++
++/* IBM C 6 for AIX is almost-ANSI by default, but it replaces macro parameters
++   inside strings and character constants.  */
++#define FOO(x) '\''x'\''
++int xlc6_cc_array[FOO(a) == '\''x'\'' ? 1 : -1];
++
++int test (int i, double x);
++struct s1 {int (*f) (int a);};
++struct s2 {int (*f) (double a);};
++int pairnames (int, char **, int *(*)(struct buf *, struct stat *, int),
++               int, int);'
++
++# Test code for whether the C compiler supports C89 (body of main).
++ac_c_conftest_c89_main='
++ok |= (argc == 0 || f (e, argv, 0) != argv[0] || f (e, argv, 1) != argv[1]);
++'
++
++# Test code for whether the C compiler supports C99 (global declarations)
++ac_c_conftest_c99_globals='
++// Does the compiler advertise C99 conformance?
++#if !defined __STDC_VERSION__ || __STDC_VERSION__ < 199901L
++# error "Compiler does not advertise C99 conformance"
++#endif
++
++#include <stdbool.h>
++extern int puts (const char *);
++extern int printf (const char *, ...);
++extern int dprintf (int, const char *, ...);
++extern void *malloc (size_t);
++
++// Check varargs macros.  These examples are taken from C99 6.10.3.5.
++// dprintf is used instead of fprintf to avoid needing to declare
++// FILE and stderr.
++#define debug(...) dprintf (2, __VA_ARGS__)
++#define showlist(...) puts (#__VA_ARGS__)
++#define report(test,...) ((test) ? puts (#test) : printf (__VA_ARGS__))
++static void
++test_varargs_macros (void)
++{
++  int x = 1234;
++  int y = 5678;
++  debug ("Flag");
++  debug ("X = %d\n", x);
++  showlist (The first, second, and third items.);
++  report (x>y, "x is %d but y is %d", x, y);
++}
++
++// Check long long types.
++#define BIG64 18446744073709551615ull
++#define BIG32 4294967295ul
++#define BIG_OK (BIG64 / BIG32 == 4294967297ull && BIG64 % BIG32 == 0)
++#if !BIG_OK
++  #error "your preprocessor is broken"
++#endif
++#if BIG_OK
++#else
++  #error "your preprocessor is broken"
++#endif
++static long long int bignum = -9223372036854775807LL;
++static unsigned long long int ubignum = BIG64;
++
++struct incomplete_array
++{
++  int datasize;
++  double data[];
++};
++
++struct named_init {
++  int number;
++  const wchar_t *name;
++  double average;
++};
++
++typedef const char *ccp;
++
++static inline int
++test_restrict (ccp restrict text)
++{
++  // See if C++-style comments work.
++  // Iterate through items via the restricted pointer.
++  // Also check for declarations in for loops.
++  for (unsigned int i = 0; *(text+i) != '\''\0'\''; ++i)
++    continue;
++  return 0;
++}
++
++// Check varargs and va_copy.
++static bool
++test_varargs (const char *format, ...)
++{
++  va_list args;
++  va_start (args, format);
++  va_list args_copy;
++  va_copy (args_copy, args);
++
++  const char *str = "";
++  int number = 0;
++  float fnumber = 0;
++
++  while (*format)
++    {
++      switch (*format++)
++	{
++	case '\''s'\'': // string
++	  str = va_arg (args_copy, const char *);
++	  break;
++	case '\''d'\'': // int
++	  number = va_arg (args_copy, int);
++	  break;
++	case '\''f'\'': // float
++	  fnumber = va_arg (args_copy, double);
++	  break;
++	default:
++	  break;
++	}
++    }
++  va_end (args_copy);
++  va_end (args);
++
++  return *str && number && fnumber;
++}
++'
++
++# Test code for whether the C compiler supports C99 (body of main).
++ac_c_conftest_c99_main='
++  // Check bool.
++  _Bool success = false;
++  success |= (argc != 0);
++
++  // Check restrict.
++  if (test_restrict ("String literal") == 0)
++    success = true;
++  char *restrict newvar = "Another string";
++
++  // Check varargs.
++  success &= test_varargs ("s, d'\'' f .", "string", 65, 34.234);
++  test_varargs_macros ();
++
++  // Check flexible array members.
++  struct incomplete_array *ia =
++    malloc (sizeof (struct incomplete_array) + (sizeof (double) * 10));
++  ia->datasize = 10;
++  for (int i = 0; i < ia->datasize; ++i)
++    ia->data[i] = i * 1.234;
++
++  // Check named initializers.
++  struct named_init ni = {
++    .number = 34,
++    .name = L"Test wide string",
++    .average = 543.34343,
++  };
++
++  ni.number = 58;
++
++  int dynamic_array[ni.number];
++  dynamic_array[0] = argv[0][0];
++  dynamic_array[ni.number - 1] = 543;
++
++  // work around unused variable warnings
++  ok |= (!success || bignum == 0LL || ubignum == 0uLL || newvar[0] == '\''x'\''
++	 || dynamic_array[ni.number - 1] != 543);
++'
++
++# Test code for whether the C compiler supports C11 (global declarations)
++ac_c_conftest_c11_globals='
++// Does the compiler advertise C11 conformance?
++#if !defined __STDC_VERSION__ || __STDC_VERSION__ < 201112L
++# error "Compiler does not advertise C11 conformance"
++#endif
++
++// Check _Alignas.
++char _Alignas (double) aligned_as_double;
++char _Alignas (0) no_special_alignment;
++extern char aligned_as_int;
++char _Alignas (0) _Alignas (int) aligned_as_int;
++
++// Check _Alignof.
++enum
++{
++  int_alignment = _Alignof (int),
++  int_array_alignment = _Alignof (int[100]),
++  char_alignment = _Alignof (char)
++};
++_Static_assert (0 < -_Alignof (int), "_Alignof is signed");
++
++// Check _Noreturn.
++int _Noreturn does_not_return (void) { for (;;) continue; }
++
++// Check _Static_assert.
++struct test_static_assert
++{
++  int x;
++  _Static_assert (sizeof (int) <= sizeof (long int),
++                  "_Static_assert does not work in struct");
++  long int y;
++};
++
++// Check UTF-8 literals.
++#define u8 syntax error!
++char const utf8_literal[] = u8"happens to be ASCII" "another string";
++
++// Check duplicate typedefs.
++typedef long *long_ptr;
++typedef long int *long_ptr;
++typedef long_ptr long_ptr;
++
++// Anonymous structures and unions -- taken from C11 6.7.2.1 Example 1.
++struct anonymous
++{
++  union {
++    struct { int i; int j; };
++    struct { int k; long int l; } w;
++  };
++  int m;
++} v1;
++'
++
++# Test code for whether the C compiler supports C11 (body of main).
++ac_c_conftest_c11_main='
++  _Static_assert ((offsetof (struct anonymous, i)
++		   == offsetof (struct anonymous, w.k)),
++		  "Anonymous union alignment botch");
++  v1.i = 2;
++  v1.w.k = 5;
++  ok |= v1.i != 5;
++'
++
++# Test code for whether the C compiler supports C11 (complete).
++ac_c_conftest_c11_program="${ac_c_conftest_c89_globals}
++${ac_c_conftest_c99_globals}
++${ac_c_conftest_c11_globals}
++
++int
++main (int argc, char **argv)
++{
++  int ok = 0;
++  ${ac_c_conftest_c89_main}
++  ${ac_c_conftest_c99_main}
++  ${ac_c_conftest_c11_main}
++  return ok;
++}
++"
++
++# Test code for whether the C compiler supports C99 (complete).
++ac_c_conftest_c99_program="${ac_c_conftest_c89_globals}
++${ac_c_conftest_c99_globals}
++
++int
++main (int argc, char **argv)
++{
++  int ok = 0;
++  ${ac_c_conftest_c89_main}
++  ${ac_c_conftest_c99_main}
++  return ok;
++}
++"
++
++# Test code for whether the C compiler supports C89 (complete).
++ac_c_conftest_c89_program="${ac_c_conftest_c89_globals}
++
++int
++main (int argc, char **argv)
++{
++  int ok = 0;
++  ${ac_c_conftest_c89_main}
++  return ok;
++}
++"
++
++# Test code for whether the C++ compiler supports C++98 (global declarations)
++ac_cxx_conftest_cxx98_globals='
++// Does the compiler advertise C++98 conformance?
++#if !defined __cplusplus || __cplusplus < 199711L
++# error "Compiler does not advertise C++98 conformance"
++#endif
++
++// These inclusions are to reject old compilers that
++// lack the unsuffixed header files.
++#include <cstdlib>
++#include <exception>
++
++// <cassert> and <cstring> are *not* freestanding headers in C++98.
++extern void assert (int);
++namespace std {
++  extern int strcmp (const char *, const char *);
++}
++
++// Namespaces, exceptions, and templates were all added after "C++ 2.0".
++using std::exception;
++using std::strcmp;
++
++namespace {
++
++void test_exception_syntax()
++{
++  try {
++    throw "test";
++  } catch (const char *s) {
++    // Extra parentheses suppress a warning when building autoconf itself,
++    // due to lint rules shared with more typical C programs.
++    assert (!(strcmp) (s, "test"));
++  }
++}
++
++template <typename T> struct test_template
++{
++  T const val;
++  explicit test_template(T t) : val(t) {}
++  template <typename U> T add(U u) { return static_cast<T>(u) + val; }
++};
++
++} // anonymous namespace
++'
++
++# Test code for whether the C++ compiler supports C++98 (body of main)
++ac_cxx_conftest_cxx98_main='
++  assert (argc);
++  assert (! argv[0]);
++{
++  test_exception_syntax ();
++  test_template<double> tt (2.0);
++  assert (tt.add (4) == 6.0);
++  assert (true && !false);
++}
++'
++
++# Test code for whether the C++ compiler supports C++11 (global declarations)
++ac_cxx_conftest_cxx11_globals='
++// Does the compiler advertise C++ 2011 conformance?
++#if !defined __cplusplus || __cplusplus < 201103L
++# error "Compiler does not advertise C++11 conformance"
++#endif
++
++namespace cxx11test
++{
++  constexpr int get_val() { return 20; }
++
++  struct testinit
++  {
++    int i;
++    double d;
++  };
++
++  class delegate
++  {
++  public:
++    delegate(int n) : n(n) {}
++    delegate(): delegate(2354) {}
++
++    virtual int getval() { return this->n; };
++  protected:
++    int n;
++  };
++
++  class overridden : public delegate
++  {
++  public:
++    overridden(int n): delegate(n) {}
++    virtual int getval() override final { return this->n * 2; }
++  };
++
++  class nocopy
++  {
++  public:
++    nocopy(int i): i(i) {}
++    nocopy() = default;
++    nocopy(const nocopy&) = delete;
++    nocopy & operator=(const nocopy&) = delete;
++  private:
++    int i;
++  };
++
++  // for testing lambda expressions
++  template <typename Ret, typename Fn> Ret eval(Fn f, Ret v)
++  {
++    return f(v);
++  }
++
++  // for testing variadic templates and trailing return types
++  template <typename V> auto sum(V first) -> V
++  {
++    return first;
++  }
++  template <typename V, typename... Args> auto sum(V first, Args... rest) -> V
++  {
++    return first + sum(rest...);
++  }
++}
++'
++
++# Test code for whether the C++ compiler supports C++11 (body of main)
++ac_cxx_conftest_cxx11_main='
++{
++  // Test auto and decltype
++  auto a1 = 6538;
++  auto a2 = 48573953.4;
++  auto a3 = "String literal";
++
++  int total = 0;
++  for (auto i = a3; *i; ++i) { total += *i; }
++
++  decltype(a2) a4 = 34895.034;
++}
++{
++  // Test constexpr
++  short sa[cxx11test::get_val()] = { 0 };
++}
++{
++  // Test initializer lists
++  cxx11test::testinit il = { 4323, 435234.23544 };
++}
++{
++  // Test range-based for
++  int array[] = {9, 7, 13, 15, 4, 18, 12, 10, 5, 3,
++                 14, 19, 17, 8, 6, 20, 16, 2, 11, 1};
++  for (auto &x : array) { x += 23; }
++}
++{
++  // Test lambda expressions
++  using cxx11test::eval;
++  assert (eval ([](int x) { return x*2; }, 21) == 42);
++  double d = 2.0;
++  assert (eval ([&](double x) { return d += x; }, 3.0) == 5.0);
++  assert (d == 5.0);
++  assert (eval ([=](double x) mutable { return d += x; }, 4.0) == 9.0);
++  assert (d == 5.0);
++}
++{
++  // Test use of variadic templates
++  using cxx11test::sum;
++  auto a = sum(1);
++  auto b = sum(1, 2);
++  auto c = sum(1.0, 2.0, 3.0);
++}
++{
++  // Test constructor delegation
++  cxx11test::delegate d1;
++  cxx11test::delegate d2();
++  cxx11test::delegate d3(45);
++}
++{
++  // Test override and final
++  cxx11test::overridden o1(55464);
++}
++{
++  // Test nullptr
++  char *c = nullptr;
++}
++{
++  // Test template brackets
++  test_template<::test_template<int>> v(test_template<int>(12));
++}
++{
++  // Unicode literals
++  char const *utf8 = u8"UTF-8 string \u2500";
++  char16_t const *utf16 = u"UTF-8 string \u2500";
++  char32_t const *utf32 = U"UTF-32 string \u2500";
++}
++'
++
++# Test code for whether the C compiler supports C++11 (complete).
++ac_cxx_conftest_cxx11_program="${ac_cxx_conftest_cxx98_globals}
++${ac_cxx_conftest_cxx11_globals}
++
++int
++main (int argc, char **argv)
++{
++  int ok = 0;
++  ${ac_cxx_conftest_cxx98_main}
++  ${ac_cxx_conftest_cxx11_main}
++  return ok;
++}
++"
++
++# Test code for whether the C compiler supports C++98 (complete).
++ac_cxx_conftest_cxx98_program="${ac_cxx_conftest_cxx98_globals}
++int
++main (int argc, char **argv)
++{
++  int ok = 0;
++  ${ac_cxx_conftest_cxx98_main}
++  return ok;
++}
++"
++
++as_fn_append ac_header_cxx_list " stdio.h stdio_h HAVE_STDIO_H"
++as_fn_append ac_header_cxx_list " stdlib.h stdlib_h HAVE_STDLIB_H"
++as_fn_append ac_header_cxx_list " string.h string_h HAVE_STRING_H"
++as_fn_append ac_header_cxx_list " inttypes.h inttypes_h HAVE_INTTYPES_H"
++as_fn_append ac_header_cxx_list " stdint.h stdint_h HAVE_STDINT_H"
++as_fn_append ac_header_cxx_list " strings.h strings_h HAVE_STRINGS_H"
++as_fn_append ac_header_cxx_list " sys/stat.h sys_stat_h HAVE_SYS_STAT_H"
++as_fn_append ac_header_cxx_list " sys/types.h sys_types_h HAVE_SYS_TYPES_H"
++as_fn_append ac_header_cxx_list " unistd.h unistd_h HAVE_UNISTD_H"
++
++# Auxiliary files required by this configure script.
++ac_aux_files="install-sh config.guess config.sub"
++
++# Locations in which to look for auxiliary files.
++ac_aux_dir_candidates="${srcdir}/bin/scripts"
++
++# Search for a directory containing all of the required auxiliary files,
++# $ac_aux_files, from the $PATH-style list $ac_aux_dir_candidates.
++# If we don't find one directory that contains all the files we need,
++# we report the set of missing files from the *first* directory in
++# $ac_aux_dir_candidates and give up.
++ac_missing_aux_files=""
++ac_first_candidate=:
++printf "%s\n" "$as_me:${as_lineno-$LINENO}: looking for aux files: $ac_aux_files" >&5
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++as_found=false
++for as_dir in $ac_aux_dir_candidates
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++  as_found=:
++
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}:  trying $as_dir" >&5
++  ac_aux_dir_found=yes
++  ac_install_sh=
++  for ac_aux in $ac_aux_files
++  do
++    # As a special case, if "install-sh" is required, that requirement
++    # can be satisfied by any of "install-sh", "install.sh", or "shtool",
++    # and $ac_install_sh is set appropriately for whichever one is found.
++    if test x"$ac_aux" = x"install-sh"
++    then
++      if test -f "${as_dir}install-sh"; then
++        printf "%s\n" "$as_me:${as_lineno-$LINENO}:   ${as_dir}install-sh found" >&5
++        ac_install_sh="${as_dir}install-sh -c"
++      elif test -f "${as_dir}install.sh"; then
++        printf "%s\n" "$as_me:${as_lineno-$LINENO}:   ${as_dir}install.sh found" >&5
++        ac_install_sh="${as_dir}install.sh -c"
++      elif test -f "${as_dir}shtool"; then
++        printf "%s\n" "$as_me:${as_lineno-$LINENO}:   ${as_dir}shtool found" >&5
++        ac_install_sh="${as_dir}shtool install -c"
++      else
++        ac_aux_dir_found=no
++        if $ac_first_candidate; then
++          ac_missing_aux_files="${ac_missing_aux_files} install-sh"
++        else
++          break
++        fi
++      fi
++    else
++      if test -f "${as_dir}${ac_aux}"; then
++        printf "%s\n" "$as_me:${as_lineno-$LINENO}:   ${as_dir}${ac_aux} found" >&5
++      else
++        ac_aux_dir_found=no
++        if $ac_first_candidate; then
++          ac_missing_aux_files="${ac_missing_aux_files} ${ac_aux}"
++        else
++          break
++        fi
++      fi
++    fi
++  done
++  if test "$ac_aux_dir_found" = yes; then
++    ac_aux_dir="$as_dir"
++    break
++  fi
++  ac_first_candidate=false
++
++  as_found=false
++done
++IFS=$as_save_IFS
++if $as_found
++then :
++
++else $as_nop
++  as_fn_error $? "cannot find required auxiliary files:$ac_missing_aux_files" "$LINENO" 5
++fi
++
++
++# These three variables are undocumented and unsupported,
++# and are intended to be withdrawn in a future Autoconf release.
++# They can cause serious problems if a builder's source tree is in a directory
++# whose full name contains unusual characters.
++if test -f "${ac_aux_dir}config.guess"; then
++  ac_config_guess="$SHELL ${ac_aux_dir}config.guess"
++fi
++if test -f "${ac_aux_dir}config.sub"; then
++  ac_config_sub="$SHELL ${ac_aux_dir}config.sub"
++fi
++if test -f "$ac_aux_dir/configure"; then
++  ac_configure="$SHELL ${ac_aux_dir}configure"
++fi
++
+ # Check that the precious variables saved in the cache have kept the same
+ # value.
+ ac_cache_corrupted=false
+@@ -2662,12 +3224,12 @@
+   eval ac_new_val=\$ac_env_${ac_var}_value
+   case $ac_old_set,$ac_new_set in
+     set,)
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' was set to \`$ac_old_val' in the previous run" >&5
+-$as_echo "$as_me: error: \`$ac_var' was set to \`$ac_old_val' in the previous run" >&2;}
++      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' was set to \`$ac_old_val' in the previous run" >&5
++printf "%s\n" "$as_me: error: \`$ac_var' was set to \`$ac_old_val' in the previous run" >&2;}
+       ac_cache_corrupted=: ;;
+     ,set)
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' was not set in the previous run" >&5
+-$as_echo "$as_me: error: \`$ac_var' was not set in the previous run" >&2;}
++      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' was not set in the previous run" >&5
++printf "%s\n" "$as_me: error: \`$ac_var' was not set in the previous run" >&2;}
+       ac_cache_corrupted=: ;;
+     ,);;
+     *)
+@@ -2676,24 +3238,24 @@
+ 	ac_old_val_w=`echo x $ac_old_val`
+ 	ac_new_val_w=`echo x $ac_new_val`
+ 	if test "$ac_old_val_w" != "$ac_new_val_w"; then
+-	  { $as_echo "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' has changed since the previous run:" >&5
+-$as_echo "$as_me: error: \`$ac_var' has changed since the previous run:" >&2;}
++	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' has changed since the previous run:" >&5
++printf "%s\n" "$as_me: error: \`$ac_var' has changed since the previous run:" >&2;}
+ 	  ac_cache_corrupted=:
+ 	else
+-	  { $as_echo "$as_me:${as_lineno-$LINENO}: warning: ignoring whitespace changes in \`$ac_var' since the previous run:" >&5
+-$as_echo "$as_me: warning: ignoring whitespace changes in \`$ac_var' since the previous run:" >&2;}
++	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: warning: ignoring whitespace changes in \`$ac_var' since the previous run:" >&5
++printf "%s\n" "$as_me: warning: ignoring whitespace changes in \`$ac_var' since the previous run:" >&2;}
+ 	  eval $ac_var=\$ac_old_val
+ 	fi
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}:   former value:  \`$ac_old_val'" >&5
+-$as_echo "$as_me:   former value:  \`$ac_old_val'" >&2;}
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}:   current value: \`$ac_new_val'" >&5
+-$as_echo "$as_me:   current value: \`$ac_new_val'" >&2;}
++	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}:   former value:  \`$ac_old_val'" >&5
++printf "%s\n" "$as_me:   former value:  \`$ac_old_val'" >&2;}
++	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}:   current value: \`$ac_new_val'" >&5
++printf "%s\n" "$as_me:   current value: \`$ac_new_val'" >&2;}
+       fi;;
+   esac
+   # Pass precious variables to config.status.
+   if test "$ac_new_set" = set; then
+     case $ac_new_val in
+-    *\'*) ac_arg=$ac_var=`$as_echo "$ac_new_val" | sed "s/'/'\\\\\\\\''/g"` ;;
++    *\'*) ac_arg=$ac_var=`printf "%s\n" "$ac_new_val" | sed "s/'/'\\\\\\\\''/g"` ;;
+     *) ac_arg=$ac_var=$ac_new_val ;;
+     esac
+     case " $ac_configure_args " in
+@@ -2703,11 +3265,12 @@
+   fi
+ done
+ if $ac_cache_corrupted; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: error: changes in the environment can compromise the build" >&5
+-$as_echo "$as_me: error: changes in the environment can compromise the build" >&2;}
+-  as_fn_error $? "run \`make distclean' and/or \`rm $cache_file' and start over" "$LINENO" 5
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: changes in the environment can compromise the build" >&5
++printf "%s\n" "$as_me: error: changes in the environment can compromise the build" >&2;}
++  as_fn_error $? "run \`${MAKE-make} distclean' and/or \`rm $cache_file'
++	    and start over" "$LINENO" 5
+ fi
+ ## -------------------- ##
+ ## Main body of script. ##
+@@ -2723,56 +3286,32 @@
+ 
+ 
+ 
+-ac_aux_dir=
+-for ac_dir in bin/scripts "$srcdir"/bin/scripts; do
+-  if test -f "$ac_dir/install-sh"; then
+-    ac_aux_dir=$ac_dir
+-    ac_install_sh="$ac_aux_dir/install-sh -c"
+-    break
+-  elif test -f "$ac_dir/install.sh"; then
+-    ac_aux_dir=$ac_dir
+-    ac_install_sh="$ac_aux_dir/install.sh -c"
+-    break
+-  elif test -f "$ac_dir/shtool"; then
+-    ac_aux_dir=$ac_dir
+-    ac_install_sh="$ac_aux_dir/shtool install -c"
+-    break
+-  fi
+-done
+-if test -z "$ac_aux_dir"; then
+-  as_fn_error $? "cannot find install-sh, install.sh, or shtool in bin/scripts \"$srcdir\"/bin/scripts" "$LINENO" 5
+-fi
+ 
+-# These three variables are undocumented and unsupported,
+-# and are intended to be withdrawn in a future Autoconf release.
+-# They can cause serious problems if a builder's source tree is in a directory
+-# whose full name contains unusual characters.
+-ac_config_guess="$SHELL $ac_aux_dir/config.guess"  # Please don't use this var.
+-ac_config_sub="$SHELL $ac_aux_dir/config.sub"  # Please don't use this var.
+-ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
+ 
+ 
+ 
+-# Make sure we can run config.sub.
+-$SHELL "$ac_aux_dir/config.sub" sun4 >/dev/null 2>&1 ||
+-  as_fn_error $? "cannot run $SHELL $ac_aux_dir/config.sub" "$LINENO" 5
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking build system type" >&5
+-$as_echo_n "checking build system type... " >&6; }
+-if ${ac_cv_build+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++  # Make sure we can run config.sub.
++$SHELL "${ac_aux_dir}config.sub" sun4 >/dev/null 2>&1 ||
++  as_fn_error $? "cannot run $SHELL ${ac_aux_dir}config.sub" "$LINENO" 5
++
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking build system type" >&5
++printf %s "checking build system type... " >&6; }
++if test ${ac_cv_build+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_build_alias=$build_alias
+ test "x$ac_build_alias" = x &&
+-  ac_build_alias=`$SHELL "$ac_aux_dir/config.guess"`
++  ac_build_alias=`$SHELL "${ac_aux_dir}config.guess"`
+ test "x$ac_build_alias" = x &&
+   as_fn_error $? "cannot guess build type; you must specify one" "$LINENO" 5
+-ac_cv_build=`$SHELL "$ac_aux_dir/config.sub" $ac_build_alias` ||
+-  as_fn_error $? "$SHELL $ac_aux_dir/config.sub $ac_build_alias failed" "$LINENO" 5
++ac_cv_build=`$SHELL "${ac_aux_dir}config.sub" $ac_build_alias` ||
++  as_fn_error $? "$SHELL ${ac_aux_dir}config.sub $ac_build_alias failed" "$LINENO" 5
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build" >&5
+-$as_echo "$ac_cv_build" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build" >&5
++printf "%s\n" "$ac_cv_build" >&6; }
+ case $ac_cv_build in
+ *-*-*) ;;
+ *) as_fn_error $? "invalid value of canonical build" "$LINENO" 5;;
+@@ -2791,21 +3330,22 @@
+ case $build_os in *\ *) build_os=`echo "$build_os" | sed 's/ /-/g'`;; esac
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking host system type" >&5
+-$as_echo_n "checking host system type... " >&6; }
+-if ${ac_cv_host+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking host system type" >&5
++printf %s "checking host system type... " >&6; }
++if test ${ac_cv_host+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test "x$host_alias" = x; then
+   ac_cv_host=$ac_cv_build
+ else
+-  ac_cv_host=`$SHELL "$ac_aux_dir/config.sub" $host_alias` ||
+-    as_fn_error $? "$SHELL $ac_aux_dir/config.sub $host_alias failed" "$LINENO" 5
++  ac_cv_host=`$SHELL "${ac_aux_dir}config.sub" $host_alias` ||
++    as_fn_error $? "$SHELL ${ac_aux_dir}config.sub $host_alias failed" "$LINENO" 5
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_host" >&5
+-$as_echo "$ac_cv_host" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_host" >&5
++printf "%s\n" "$ac_cv_host" >&6; }
+ case $ac_cv_host in
+ *-*-*) ;;
+ *) as_fn_error $? "invalid value of canonical host" "$LINENO" 5;;
+@@ -2841,6 +3381,15 @@
+ 
+ 
+ 
++
++
++
++
++
++
++
++
++
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -2849,11 +3398,12 @@
+ if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}gcc", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}gcc; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$CC"; then
+   ac_cv_prog_CC="$CC" # Let the user override the test.
+ else
+@@ -2861,11 +3411,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_CC="${ac_tool_prefix}gcc"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -2876,11 +3430,11 @@
+ fi
+ CC=$ac_cv_prog_CC
+ if test -n "$CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+-$as_echo "$CC" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
++printf "%s\n" "$CC" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -2889,11 +3443,12 @@
+   ac_ct_CC=$CC
+   # Extract the first word of "gcc", so it can be a program name with args.
+ set dummy gcc; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_ac_ct_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_CC+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$ac_ct_CC"; then
+   ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
+ else
+@@ -2901,11 +3456,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_ac_ct_CC="gcc"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -2916,11 +3475,11 @@
+ fi
+ ac_ct_CC=$ac_cv_prog_ac_ct_CC
+ if test -n "$ac_ct_CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+-$as_echo "$ac_ct_CC" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
++printf "%s\n" "$ac_ct_CC" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+   if test "x$ac_ct_CC" = x; then
+@@ -2928,8 +3487,8 @@
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     CC=$ac_ct_CC
+@@ -2942,11 +3501,12 @@
+           if test -n "$ac_tool_prefix"; then
+     # Extract the first word of "${ac_tool_prefix}cc", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}cc; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$CC"; then
+   ac_cv_prog_CC="$CC" # Let the user override the test.
+ else
+@@ -2954,11 +3514,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_CC="${ac_tool_prefix}cc"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -2969,11 +3533,11 @@
+ fi
+ CC=$ac_cv_prog_CC
+ if test -n "$CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+-$as_echo "$CC" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
++printf "%s\n" "$CC" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -2982,11 +3546,12 @@
+ if test -z "$CC"; then
+   # Extract the first word of "cc", so it can be a program name with args.
+ set dummy cc; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$CC"; then
+   ac_cv_prog_CC="$CC" # Let the user override the test.
+ else
+@@ -2995,15 +3560,19 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    if test "$as_dir/$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    if test "$as_dir$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
+        ac_prog_rejected=yes
+        continue
+      fi
+     ac_cv_prog_CC="cc"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -3019,7 +3588,7 @@
+     # However, it has the same basename, so the bogon will be chosen
+     # first if we set CC to just the basename; use the full file name.
+     shift
+-    ac_cv_prog_CC="$as_dir/$ac_word${1+' '}$@"
++    ac_cv_prog_CC="$as_dir$ac_word${1+' '}$@"
+   fi
+ fi
+ fi
+@@ -3026,11 +3595,11 @@
+ fi
+ CC=$ac_cv_prog_CC
+ if test -n "$CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+-$as_echo "$CC" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
++printf "%s\n" "$CC" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -3041,11 +3610,12 @@
+   do
+     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+ set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$CC"; then
+   ac_cv_prog_CC="$CC" # Let the user override the test.
+ else
+@@ -3053,11 +3623,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_CC="$ac_tool_prefix$ac_prog"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -3068,11 +3642,11 @@
+ fi
+ CC=$ac_cv_prog_CC
+ if test -n "$CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+-$as_echo "$CC" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
++printf "%s\n" "$CC" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -3085,11 +3659,12 @@
+ do
+   # Extract the first word of "$ac_prog", so it can be a program name with args.
+ set dummy $ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_ac_ct_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_CC+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$ac_ct_CC"; then
+   ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
+ else
+@@ -3097,11 +3672,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_ac_ct_CC="$ac_prog"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -3112,11 +3691,11 @@
+ fi
+ ac_ct_CC=$ac_cv_prog_ac_ct_CC
+ if test -n "$ac_ct_CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+-$as_echo "$ac_ct_CC" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
++printf "%s\n" "$ac_ct_CC" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -3128,8 +3707,8 @@
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     CC=$ac_ct_CC
+@@ -3137,18 +3716,122 @@
+ fi
+ 
+ fi
++if test -z "$CC"; then
++  if test -n "$ac_tool_prefix"; then
++  # Extract the first word of "${ac_tool_prefix}clang", so it can be a program name with args.
++set dummy ${ac_tool_prefix}clang; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$CC"; then
++  ac_cv_prog_CC="$CC" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_CC="${ac_tool_prefix}clang"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
+ 
++fi
++fi
++CC=$ac_cv_prog_CC
++if test -n "$CC"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
++printf "%s\n" "$CC" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
+ 
+-test -z "$CC" && { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++
++fi
++if test -z "$ac_cv_prog_CC"; then
++  ac_ct_CC=$CC
++  # Extract the first word of "clang", so it can be a program name with args.
++set dummy clang; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_CC+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$ac_ct_CC"; then
++  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_ac_ct_CC="clang"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++ac_ct_CC=$ac_cv_prog_ac_ct_CC
++if test -n "$ac_ct_CC"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
++printf "%s\n" "$ac_ct_CC" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++  if test "x$ac_ct_CC" = x; then
++    CC=""
++  else
++    case $cross_compiling:$ac_tool_warned in
++yes:)
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++ac_tool_warned=yes ;;
++esac
++    CC=$ac_ct_CC
++  fi
++else
++  CC="$ac_cv_prog_CC"
++fi
++
++fi
++
++
++test -z "$CC" && { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error $? "no acceptable C compiler found in \$PATH
+ See \`config.log' for more details" "$LINENO" 5; }
+ 
+ # Provide some information about the compiler.
+-$as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
++printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
+ set X $ac_compile
+ ac_compiler=$2
+-for ac_option in --version -v -V -qversion; do
++for ac_option in --version -v -V -qversion -version; do
+   { { ac_try="$ac_compiler $ac_option >&5"
+ case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -3155,7 +3838,7 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_compiler $ac_option >&5") 2>conftest.err
+   ac_status=$?
+   if test -s conftest.err; then
+@@ -3165,7 +3848,7 @@
+     cat conftest.er1 >&5
+   fi
+   rm -f conftest.er1 conftest.err
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }
+ done
+ 
+@@ -3173,7 +3856,7 @@
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   ;
+@@ -3185,9 +3868,9 @@
+ # Try to create an executable without -o first, disregard a.out.
+ # It will help us diagnose broken compilers, and finding out an intuition
+ # of exeext.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
+-$as_echo_n "checking whether the C compiler works... " >&6; }
+-ac_link_default=`$as_echo "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
++printf %s "checking whether the C compiler works... " >&6; }
++ac_link_default=`printf "%s\n" "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
+ 
+ # The possible output files:
+ ac_files="a.out conftest.exe conftest a.exe a_out.exe b.out conftest.*"
+@@ -3208,11 +3891,12 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_link_default") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then :
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++then :
+   # Autoconf-2.13 could set the ac_cv_exeext variable to `no'.
+ # So ignore a value of `no', otherwise this would lead to `EXEEXT = no'
+ # in a Makefile.  We should not override ac_cv_exeext if it was cached,
+@@ -3229,7 +3913,7 @@
+ 	# certainly right.
+ 	break;;
+     *.* )
+-	if test "${ac_cv_exeext+set}" = set && test "$ac_cv_exeext" != no;
++	if test ${ac_cv_exeext+y} && test "$ac_cv_exeext" != no;
+ 	then :; else
+ 	   ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
+ 	fi
+@@ -3245,33 +3929,34 @@
+ done
+ test "$ac_cv_exeext" = no && ac_cv_exeext=
+ 
+-else
++else $as_nop
+   ac_file=''
+ fi
+-if test -z "$ac_file"; then :
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-$as_echo "$as_me: failed program was:" >&5
++if test -z "$ac_file"
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+-{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "C compiler cannot create executables
+ See \`config.log' for more details" "$LINENO" 5; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++printf "%s\n" "yes" >&6; }
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
+-$as_echo_n "checking for C compiler default output file name... " >&6; }
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
+-$as_echo "$ac_file" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
++printf %s "checking for C compiler default output file name... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
++printf "%s\n" "$ac_file" >&6; }
+ ac_exeext=$ac_cv_exeext
+ 
+ rm -f -r a.out a.out.dSYM a.exe conftest$ac_cv_exeext b.out
+ ac_clean_files=$ac_clean_files_save
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
+-$as_echo_n "checking for suffix of executables... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
++printf %s "checking for suffix of executables... " >&6; }
+ if { { ac_try="$ac_link"
+ case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -3278,11 +3963,12 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_link") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then :
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++then :
+   # If both `conftest.exe' and `conftest' are `present' (well, observable)
+ # catch `conftest.exe'.  For instance with Cygwin, `ls conftest' will
+ # work properly (i.e., refer to `conftest.exe'), while it won't with
+@@ -3296,15 +3982,15 @@
+     * ) break;;
+   esac
+ done
+-else
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++else $as_nop
++  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error $? "cannot compute suffix of executables: cannot compile and link
+ See \`config.log' for more details" "$LINENO" 5; }
+ fi
+ rm -f conftest conftest$ac_cv_exeext
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_exeext" >&5
+-$as_echo "$ac_cv_exeext" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_exeext" >&5
++printf "%s\n" "$ac_cv_exeext" >&6; }
+ 
+ rm -f conftest.$ac_ext
+ EXEEXT=$ac_cv_exeext
+@@ -3313,7 +3999,7 @@
+ /* end confdefs.h.  */
+ #include <stdio.h>
+ int
+-main ()
++main (void)
+ {
+ FILE *f = fopen ("conftest.out", "w");
+  return ferror (f) || fclose (f) != 0;
+@@ -3325,8 +4011,8 @@
+ ac_clean_files="$ac_clean_files conftest.out"
+ # Check that the compiler produces executables we can run.  If not, either
+ # the compiler is broken, or we cross compile.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
+-$as_echo_n "checking whether we are cross compiling... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
++printf %s "checking whether we are cross compiling... " >&6; }
+ if test "$cross_compiling" != yes; then
+   { { ac_try="$ac_link"
+ case "(($ac_try" in
+@@ -3334,10 +4020,10 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_link") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }
+   if { ac_try='./conftest$ac_cv_exeext'
+   { { case "(($ac_try" in
+@@ -3345,10 +4031,10 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_try") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; }; then
+     cross_compiling=no
+   else
+@@ -3355,29 +4041,30 @@
+     if test "$cross_compiling" = maybe; then
+ 	cross_compiling=yes
+     else
+-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run C compiled programs.
++	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error 77 "cannot run C compiled programs.
+ If you meant to cross compile, use \`--host'.
+ See \`config.log' for more details" "$LINENO" 5; }
+     fi
+   fi
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
+-$as_echo "$cross_compiling" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
++printf "%s\n" "$cross_compiling" >&6; }
+ 
+ rm -f conftest.$ac_ext conftest$ac_cv_exeext conftest.out
+ ac_clean_files=$ac_clean_files_save
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
+-$as_echo_n "checking for suffix of object files... " >&6; }
+-if ${ac_cv_objext+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
++printf %s "checking for suffix of object files... " >&6; }
++if test ${ac_cv_objext+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   ;
+@@ -3391,11 +4078,12 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_compile") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then :
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++then :
+   for ac_file in conftest.o conftest.obj conftest.*; do
+   test -f "$ac_file" || continue;
+   case $ac_file in
+@@ -3404,31 +4092,32 @@
+        break;;
+   esac
+ done
+-else
+-  $as_echo "$as_me: failed program was:" >&5
++else $as_nop
++  printf "%s\n" "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+-{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error $? "cannot compute suffix of object files: cannot compile
+ See \`config.log' for more details" "$LINENO" 5; }
+ fi
+ rm -f conftest.$ac_cv_objext conftest.$ac_ext
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_objext" >&5
+-$as_echo "$ac_cv_objext" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_objext" >&5
++printf "%s\n" "$ac_cv_objext" >&6; }
+ OBJEXT=$ac_cv_objext
+ ac_objext=$OBJEXT
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C compiler" >&5
+-$as_echo_n "checking whether we are using the GNU C compiler... " >&6; }
+-if ${ac_cv_c_compiler_gnu+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports GNU C" >&5
++printf %s "checking whether the compiler supports GNU C... " >&6; }
++if test ${ac_cv_c_compiler_gnu+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ #ifndef __GNUC__
+        choke me
+@@ -3438,29 +4127,33 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
++if ac_fn_c_try_compile "$LINENO"
++then :
+   ac_compiler_gnu=yes
+-else
++else $as_nop
+   ac_compiler_gnu=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ ac_cv_c_compiler_gnu=$ac_compiler_gnu
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
+-$as_echo "$ac_cv_c_compiler_gnu" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
++printf "%s\n" "$ac_cv_c_compiler_gnu" >&6; }
++ac_compiler_gnu=$ac_cv_c_compiler_gnu
++
+ if test $ac_compiler_gnu = yes; then
+   GCC=yes
+ else
+   GCC=
+ fi
+-ac_test_CFLAGS=${CFLAGS+set}
++ac_test_CFLAGS=${CFLAGS+y}
+ ac_save_CFLAGS=$CFLAGS
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
+-$as_echo_n "checking whether $CC accepts -g... " >&6; }
+-if ${ac_cv_prog_cc_g+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
++printf %s "checking whether $CC accepts -g... " >&6; }
++if test ${ac_cv_prog_cc_g+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_save_c_werror_flag=$ac_c_werror_flag
+    ac_c_werror_flag=yes
+    ac_cv_prog_cc_g=no
+@@ -3469,7 +4162,7 @@
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   ;
+@@ -3476,15 +4169,16 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
++if ac_fn_c_try_compile "$LINENO"
++then :
+   ac_cv_prog_cc_g=yes
+-else
++else $as_nop
+   CFLAGS=""
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   ;
+@@ -3491,9 +4185,10 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
++if ac_fn_c_try_compile "$LINENO"
++then :
+ 
+-else
++else $as_nop
+   ac_c_werror_flag=$ac_save_c_werror_flag
+ 	 CFLAGS="-g"
+ 	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -3500,7 +4195,7 @@
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   ;
+@@ -3507,19 +4202,20 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
++if ac_fn_c_try_compile "$LINENO"
++then :
+   ac_cv_prog_cc_g=yes
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+    ac_c_werror_flag=$ac_save_c_werror_flag
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
+-$as_echo "$ac_cv_prog_cc_g" >&6; }
+-if test "$ac_test_CFLAGS" = set; then
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
++printf "%s\n" "$ac_cv_prog_cc_g" >&6; }
++if test $ac_test_CFLAGS; then
+   CFLAGS=$ac_save_CFLAGS
+ elif test $ac_cv_prog_cc_g = yes; then
+   if test "$GCC" = yes; then
+@@ -3534,95 +4230,145 @@
+     CFLAGS=
+   fi
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CC option to accept ISO C89" >&5
+-$as_echo_n "checking for $CC option to accept ISO C89... " >&6; }
+-if ${ac_cv_prog_cc_c89+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  ac_cv_prog_cc_c89=no
++ac_prog_cc_stdc=no
++if test x$ac_prog_cc_stdc = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C11 features" >&5
++printf %s "checking for $CC option to enable C11 features... " >&6; }
++if test ${ac_cv_prog_cc_c11+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_cv_prog_cc_c11=no
+ ac_save_CC=$CC
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#include <stdarg.h>
+-#include <stdio.h>
+-struct stat;
+-/* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */
+-struct buf { int x; };
+-FILE * (*rcsopen) (struct buf *, struct stat *, int);
+-static char *e (p, i)
+-     char **p;
+-     int i;
+-{
+-  return p[i];
+-}
+-static char *f (char * (*g) (char **, int), char **p, ...)
+-{
+-  char *s;
+-  va_list v;
+-  va_start (v,p);
+-  s = g (p, va_arg (v,int));
+-  va_end (v);
+-  return s;
+-}
++$ac_c_conftest_c11_program
++_ACEOF
++for ac_arg in '' -std=gnu11
++do
++  CC="$ac_save_CC $ac_arg"
++  if ac_fn_c_try_compile "$LINENO"
++then :
++  ac_cv_prog_cc_c11=$ac_arg
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam
++  test "x$ac_cv_prog_cc_c11" != "xno" && break
++done
++rm -f conftest.$ac_ext
++CC=$ac_save_CC
++fi
+ 
+-/* OSF 4.0 Compaq cc is some sort of almost-ANSI by default.  It has
+-   function prototypes and stuff, but not '\xHH' hex character constants.
+-   These don't provoke an error unfortunately, instead are silently treated
+-   as 'x'.  The following induces an error, until -std is added to get
+-   proper ANSI mode.  Curiously '\x00'!='x' always comes out true, for an
+-   array size at least.  It's necessary to write '\x00'==0 to get something
+-   that's true only with -std.  */
+-int osf4_cc_array ['\x00' == 0 ? 1 : -1];
++if test "x$ac_cv_prog_cc_c11" = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
++printf "%s\n" "unsupported" >&6; }
++else $as_nop
++  if test "x$ac_cv_prog_cc_c11" = x
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
++printf "%s\n" "none needed" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c11" >&5
++printf "%s\n" "$ac_cv_prog_cc_c11" >&6; }
++     CC="$CC $ac_cv_prog_cc_c11"
++fi
++  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c11
++  ac_prog_cc_stdc=c11
++fi
++fi
++if test x$ac_prog_cc_stdc = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C99 features" >&5
++printf %s "checking for $CC option to enable C99 features... " >&6; }
++if test ${ac_cv_prog_cc_c99+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_cv_prog_cc_c99=no
++ac_save_CC=$CC
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++$ac_c_conftest_c99_program
++_ACEOF
++for ac_arg in '' -std=gnu99 -std=c99 -c99 -qlanglvl=extc1x -qlanglvl=extc99 -AC99 -D_STDC_C99=
++do
++  CC="$ac_save_CC $ac_arg"
++  if ac_fn_c_try_compile "$LINENO"
++then :
++  ac_cv_prog_cc_c99=$ac_arg
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam
++  test "x$ac_cv_prog_cc_c99" != "xno" && break
++done
++rm -f conftest.$ac_ext
++CC=$ac_save_CC
++fi
+ 
+-/* IBM C 6 for AIX is almost-ANSI by default, but it replaces macro parameters
+-   inside strings and character constants.  */
+-#define FOO(x) 'x'
+-int xlc6_cc_array[FOO(a) == 'x' ? 1 : -1];
+-
+-int test (int i, double x);
+-struct s1 {int (*f) (int a);};
+-struct s2 {int (*f) (double a);};
+-int pairnames (int, char **, FILE *(*)(struct buf *, struct stat *, int), int, int);
+-int argc;
+-char **argv;
+-int
+-main ()
+-{
+-return f (e, argv, 0) != argv[0]  ||  f (e, argv, 1) != argv[1];
+-  ;
+-  return 0;
+-}
++if test "x$ac_cv_prog_cc_c99" = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
++printf "%s\n" "unsupported" >&6; }
++else $as_nop
++  if test "x$ac_cv_prog_cc_c99" = x
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
++printf "%s\n" "none needed" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c99" >&5
++printf "%s\n" "$ac_cv_prog_cc_c99" >&6; }
++     CC="$CC $ac_cv_prog_cc_c99"
++fi
++  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c99
++  ac_prog_cc_stdc=c99
++fi
++fi
++if test x$ac_prog_cc_stdc = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C89 features" >&5
++printf %s "checking for $CC option to enable C89 features... " >&6; }
++if test ${ac_cv_prog_cc_c89+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_cv_prog_cc_c89=no
++ac_save_CC=$CC
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++$ac_c_conftest_c89_program
+ _ACEOF
+-for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std \
+-	-Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
++for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std -Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
+ do
+   CC="$ac_save_CC $ac_arg"
+-  if ac_fn_c_try_compile "$LINENO"; then :
++  if ac_fn_c_try_compile "$LINENO"
++then :
+   ac_cv_prog_cc_c89=$ac_arg
+ fi
+-rm -f core conftest.err conftest.$ac_objext
++rm -f core conftest.err conftest.$ac_objext conftest.beam
+   test "x$ac_cv_prog_cc_c89" != "xno" && break
+ done
+ rm -f conftest.$ac_ext
+ CC=$ac_save_CC
+-
+ fi
+-# AC_CACHE_VAL
+-case "x$ac_cv_prog_cc_c89" in
+-  x)
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
+-$as_echo "none needed" >&6; } ;;
+-  xno)
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
+-$as_echo "unsupported" >&6; } ;;
+-  *)
+-    CC="$CC $ac_cv_prog_cc_c89"
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
+-$as_echo "$ac_cv_prog_cc_c89" >&6; } ;;
+-esac
+-if test "x$ac_cv_prog_cc_c89" != xno; then :
+ 
++if test "x$ac_cv_prog_cc_c89" = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
++printf "%s\n" "unsupported" >&6; }
++else $as_nop
++  if test "x$ac_cv_prog_cc_c89" = x
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
++printf "%s\n" "none needed" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
++printf "%s\n" "$ac_cv_prog_cc_c89" >&6; }
++     CC="$CC $ac_cv_prog_cc_c89"
+ fi
++  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c89
++  ac_prog_cc_stdc=c89
++fi
++fi
+ 
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+@@ -3630,6 +4376,12 @@
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
++
++
++
++
++
++
+ ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -3640,15 +4392,16 @@
+     CXX=$CCC
+   else
+     if test -n "$ac_tool_prefix"; then
+-  for ac_prog in g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC
++  for ac_prog in g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC clang++
+   do
+     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+ set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CXX+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CXX+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$CXX"; then
+   ac_cv_prog_CXX="$CXX" # Let the user override the test.
+ else
+@@ -3656,11 +4409,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_CXX="$ac_tool_prefix$ac_prog"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -3671,11 +4428,11 @@
+ fi
+ CXX=$ac_cv_prog_CXX
+ if test -n "$CXX"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CXX" >&5
+-$as_echo "$CXX" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CXX" >&5
++printf "%s\n" "$CXX" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -3684,15 +4441,16 @@
+ fi
+ if test -z "$CXX"; then
+   ac_ct_CXX=$CXX
+-  for ac_prog in g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC
++  for ac_prog in g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC clang++
+ do
+   # Extract the first word of "$ac_prog", so it can be a program name with args.
+ set dummy $ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_ac_ct_CXX+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_CXX+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$ac_ct_CXX"; then
+   ac_cv_prog_ac_ct_CXX="$ac_ct_CXX" # Let the user override the test.
+ else
+@@ -3700,11 +4458,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_ac_ct_CXX="$ac_prog"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -3715,11 +4477,11 @@
+ fi
+ ac_ct_CXX=$ac_cv_prog_ac_ct_CXX
+ if test -n "$ac_ct_CXX"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CXX" >&5
+-$as_echo "$ac_ct_CXX" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CXX" >&5
++printf "%s\n" "$ac_ct_CXX" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -3731,8 +4493,8 @@
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     CXX=$ac_ct_CXX
+@@ -3742,7 +4504,7 @@
+   fi
+ fi
+ # Provide some information about the compiler.
+-$as_echo "$as_me:${as_lineno-$LINENO}: checking for C++ compiler version" >&5
++printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C++ compiler version" >&5
+ set X $ac_compile
+ ac_compiler=$2
+ for ac_option in --version -v -V -qversion; do
+@@ -3752,7 +4514,7 @@
+   *) ac_try_echo=$ac_try;;
+ esac
+ eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
++printf "%s\n" "$ac_try_echo"; } >&5
+   (eval "$ac_compiler $ac_option >&5") 2>conftest.err
+   ac_status=$?
+   if test -s conftest.err; then
+@@ -3762,20 +4524,21 @@
+     cat conftest.er1 >&5
+   fi
+   rm -f conftest.er1 conftest.err
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }
+ done
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C++ compiler" >&5
+-$as_echo_n "checking whether we are using the GNU C++ compiler... " >&6; }
+-if ${ac_cv_cxx_compiler_gnu+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports GNU C++" >&5
++printf %s "checking whether the compiler supports GNU C++... " >&6; }
++if test ${ac_cv_cxx_compiler_gnu+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ #ifndef __GNUC__
+        choke me
+@@ -3785,29 +4548,33 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_compiler_gnu=yes
+-else
++else $as_nop
+   ac_compiler_gnu=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ ac_cv_cxx_compiler_gnu=$ac_compiler_gnu
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_compiler_gnu" >&5
+-$as_echo "$ac_cv_cxx_compiler_gnu" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_compiler_gnu" >&5
++printf "%s\n" "$ac_cv_cxx_compiler_gnu" >&6; }
++ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
++
+ if test $ac_compiler_gnu = yes; then
+   GXX=yes
+ else
+   GXX=
+ fi
+-ac_test_CXXFLAGS=${CXXFLAGS+set}
++ac_test_CXXFLAGS=${CXXFLAGS+y}
+ ac_save_CXXFLAGS=$CXXFLAGS
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX accepts -g" >&5
+-$as_echo_n "checking whether $CXX accepts -g... " >&6; }
+-if ${ac_cv_prog_cxx_g+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CXX accepts -g" >&5
++printf %s "checking whether $CXX accepts -g... " >&6; }
++if test ${ac_cv_prog_cxx_g+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_save_cxx_werror_flag=$ac_cxx_werror_flag
+    ac_cxx_werror_flag=yes
+    ac_cv_prog_cxx_g=no
+@@ -3816,7 +4583,7 @@
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   ;
+@@ -3823,15 +4590,16 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_prog_cxx_g=yes
+-else
++else $as_nop
+   CXXFLAGS=""
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   ;
+@@ -3838,9 +4606,10 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+ 
+-else
++else $as_nop
+   ac_cxx_werror_flag=$ac_save_cxx_werror_flag
+ 	 CXXFLAGS="-g"
+ 	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -3847,7 +4616,7 @@
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   ;
+@@ -3854,19 +4623,20 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_prog_cxx_g=yes
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+    ac_cxx_werror_flag=$ac_save_cxx_werror_flag
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cxx_g" >&5
+-$as_echo "$ac_cv_prog_cxx_g" >&6; }
+-if test "$ac_test_CXXFLAGS" = set; then
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cxx_g" >&5
++printf "%s\n" "$ac_cv_prog_cxx_g" >&6; }
++if test $ac_test_CXXFLAGS; then
+   CXXFLAGS=$ac_save_CXXFLAGS
+ elif test $ac_cv_prog_cxx_g = yes; then
+   if test "$GXX" = yes; then
+@@ -3881,6 +4651,100 @@
+     CXXFLAGS=
+   fi
+ fi
++ac_prog_cxx_stdcxx=no
++if test x$ac_prog_cxx_stdcxx = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
++printf %s "checking for $CXX option to enable C++11 features... " >&6; }
++if test ${ac_cv_prog_cxx_cxx11+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_cv_prog_cxx_cxx11=no
++ac_save_CXX=$CXX
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++$ac_cxx_conftest_cxx11_program
++_ACEOF
++for ac_arg in '' -std=gnu++11 -std=gnu++0x -std=c++11 -std=c++0x -qlanglvl=extended0x -AA
++do
++  CXX="$ac_save_CXX $ac_arg"
++  if ac_fn_cxx_try_compile "$LINENO"
++then :
++  ac_cv_prog_cxx_cxx11=$ac_arg
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam
++  test "x$ac_cv_prog_cxx_cxx11" != "xno" && break
++done
++rm -f conftest.$ac_ext
++CXX=$ac_save_CXX
++fi
++
++if test "x$ac_cv_prog_cxx_cxx11" = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
++printf "%s\n" "unsupported" >&6; }
++else $as_nop
++  if test "x$ac_cv_prog_cxx_cxx11" = x
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
++printf "%s\n" "none needed" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cxx_cxx11" >&5
++printf "%s\n" "$ac_cv_prog_cxx_cxx11" >&6; }
++     CXX="$CXX $ac_cv_prog_cxx_cxx11"
++fi
++  ac_cv_prog_cxx_stdcxx=$ac_cv_prog_cxx_cxx11
++  ac_prog_cxx_stdcxx=cxx11
++fi
++fi
++if test x$ac_prog_cxx_stdcxx = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
++printf %s "checking for $CXX option to enable C++98 features... " >&6; }
++if test ${ac_cv_prog_cxx_cxx98+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_cv_prog_cxx_cxx98=no
++ac_save_CXX=$CXX
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++$ac_cxx_conftest_cxx98_program
++_ACEOF
++for ac_arg in '' -std=gnu++98 -std=c++98 -qlanglvl=extended -AA
++do
++  CXX="$ac_save_CXX $ac_arg"
++  if ac_fn_cxx_try_compile "$LINENO"
++then :
++  ac_cv_prog_cxx_cxx98=$ac_arg
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam
++  test "x$ac_cv_prog_cxx_cxx98" != "xno" && break
++done
++rm -f conftest.$ac_ext
++CXX=$ac_save_CXX
++fi
++
++if test "x$ac_cv_prog_cxx_cxx98" = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
++printf "%s\n" "unsupported" >&6; }
++else $as_nop
++  if test "x$ac_cv_prog_cxx_cxx98" = x
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
++printf "%s\n" "none needed" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cxx_cxx98" >&5
++printf "%s\n" "$ac_cv_prog_cxx_cxx98" >&6; }
++     CXX="$CXX $ac_cv_prog_cxx_cxx98"
++fi
++  ac_cv_prog_cxx_stdcxx=$ac_cv_prog_cxx_cxx98
++  ac_prog_cxx_stdcxx=cxx98
++fi
++fi
++
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -3892,18 +4756,19 @@
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to run the C preprocessor" >&5
+-$as_echo_n "checking how to run the C preprocessor... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to run the C preprocessor" >&5
++printf %s "checking how to run the C preprocessor... " >&6; }
+ # On Suns, sometimes $CPP names a directory.
+ if test -n "$CPP" && test -d "$CPP"; then
+   CPP=
+ fi
+ if test -z "$CPP"; then
+-  if ${ac_cv_prog_CPP+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-      # Double quotes because CPP needs to be expanded
+-    for CPP in "$CC -E" "$CC -E -traditional-cpp" "/lib/cpp"
++  if test ${ac_cv_prog_CPP+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++      # Double quotes because $CC needs to be expanded
++    for CPP in "$CC -E" "$CC -E -traditional-cpp" cpp /lib/cpp
+     do
+       ac_preproc_ok=false
+ for ac_c_preproc_warn_flag in '' yes
+@@ -3910,22 +4775,17 @@
+ do
+   # Use a header file that comes with gcc, so configuring glibc
+   # with a fresh cross-compiler works.
+-  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+-  # <limits.h> exists even on freestanding compilers.
+   # On the NeXT, cc -E runs the code through the compiler's parser,
+   # not just through cpp. "Syntax error" is here to catch this case.
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#ifdef __STDC__
+-# include <limits.h>
+-#else
+-# include <assert.h>
+-#endif
++#include <limits.h>
+ 		     Syntax error
+ _ACEOF
+-if ac_fn_c_try_cpp "$LINENO"; then :
++if ac_fn_c_try_cpp "$LINENO"
++then :
+ 
+-else
++else $as_nop
+   # Broken: fails on valid input.
+ continue
+ fi
+@@ -3937,10 +4797,11 @@
+ /* end confdefs.h.  */
+ #include <ac_nonexistent.h>
+ _ACEOF
+-if ac_fn_c_try_cpp "$LINENO"; then :
++if ac_fn_c_try_cpp "$LINENO"
++then :
+   # Broken: success on invalid input.
+ continue
+-else
++else $as_nop
+   # Passes both tests.
+ ac_preproc_ok=:
+ break
+@@ -3950,7 +4811,8 @@
+ done
+ # Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
+ rm -f conftest.i conftest.err conftest.$ac_ext
+-if $ac_preproc_ok; then :
++if $ac_preproc_ok
++then :
+   break
+ fi
+ 
+@@ -3962,29 +4824,24 @@
+ else
+   ac_cv_prog_CPP=$CPP
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $CPP" >&5
+-$as_echo "$CPP" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CPP" >&5
++printf "%s\n" "$CPP" >&6; }
+ ac_preproc_ok=false
+ for ac_c_preproc_warn_flag in '' yes
+ do
+   # Use a header file that comes with gcc, so configuring glibc
+   # with a fresh cross-compiler works.
+-  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+-  # <limits.h> exists even on freestanding compilers.
+   # On the NeXT, cc -E runs the code through the compiler's parser,
+   # not just through cpp. "Syntax error" is here to catch this case.
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#ifdef __STDC__
+-# include <limits.h>
+-#else
+-# include <assert.h>
+-#endif
++#include <limits.h>
+ 		     Syntax error
+ _ACEOF
+-if ac_fn_c_try_cpp "$LINENO"; then :
++if ac_fn_c_try_cpp "$LINENO"
++then :
+ 
+-else
++else $as_nop
+   # Broken: fails on valid input.
+ continue
+ fi
+@@ -3996,10 +4853,11 @@
+ /* end confdefs.h.  */
+ #include <ac_nonexistent.h>
+ _ACEOF
+-if ac_fn_c_try_cpp "$LINENO"; then :
++if ac_fn_c_try_cpp "$LINENO"
++then :
+   # Broken: success on invalid input.
+ continue
+-else
++else $as_nop
+   # Passes both tests.
+ ac_preproc_ok=:
+ break
+@@ -4009,11 +4867,12 @@
+ done
+ # Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
+ rm -f conftest.i conftest.err conftest.$ac_ext
+-if $ac_preproc_ok; then :
++if $ac_preproc_ok
++then :
+ 
+-else
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++else $as_nop
++  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error $? "C preprocessor \"$CPP\" fails sanity check
+ See \`config.log' for more details" "$LINENO" 5; }
+ fi
+@@ -4027,11 +4886,12 @@
+ if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}ranlib", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}ranlib; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_RANLIB+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_RANLIB+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$RANLIB"; then
+   ac_cv_prog_RANLIB="$RANLIB" # Let the user override the test.
+ else
+@@ -4039,11 +4899,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_RANLIB="${ac_tool_prefix}ranlib"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -4054,11 +4918,11 @@
+ fi
+ RANLIB=$ac_cv_prog_RANLIB
+ if test -n "$RANLIB"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $RANLIB" >&5
+-$as_echo "$RANLIB" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $RANLIB" >&5
++printf "%s\n" "$RANLIB" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -4067,11 +4931,12 @@
+   ac_ct_RANLIB=$RANLIB
+   # Extract the first word of "ranlib", so it can be a program name with args.
+ set dummy ranlib; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_ac_ct_RANLIB+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_RANLIB+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   if test -n "$ac_ct_RANLIB"; then
+   ac_cv_prog_ac_ct_RANLIB="$ac_ct_RANLIB" # Let the user override the test.
+ else
+@@ -4079,11 +4944,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+     ac_cv_prog_ac_ct_RANLIB="ranlib"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -4094,11 +4963,11 @@
+ fi
+ ac_ct_RANLIB=$ac_cv_prog_ac_ct_RANLIB
+ if test -n "$ac_ct_RANLIB"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_RANLIB" >&5
+-$as_echo "$ac_ct_RANLIB" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_RANLIB" >&5
++printf "%s\n" "$ac_ct_RANLIB" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+   if test "x$ac_ct_RANLIB" = x; then
+@@ -4106,8 +4975,8 @@
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     RANLIB=$ac_ct_RANLIB
+@@ -4116,7 +4985,8 @@
+   RANLIB="$ac_cv_prog_RANLIB"
+ fi
+ 
+-# Find a good install program.  We prefer a C program (faster),
++
++  # Find a good install program.  We prefer a C program (faster),
+ # so one script is as good as another.  But avoid the broken or
+ # incompatible versions:
+ # SysV /etc/install, /usr/sbin/install
+@@ -4130,20 +5000,25 @@
+ # OS/2's system install, which has a completely different semantic
+ # ./install, which can be erroneously created by make from ./install.sh.
+ # Reject install programs that cannot install multiple files.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a BSD-compatible install" >&5
+-$as_echo_n "checking for a BSD-compatible install... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a BSD-compatible install" >&5
++printf %s "checking for a BSD-compatible install... " >&6; }
+ if test -z "$INSTALL"; then
+-if ${ac_cv_path_install+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++if test ${ac_cv_path_install+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    # Account for people who put trailing slashes in PATH elements.
+-case $as_dir/ in #((
+-  ./ | .// | /[cC]/* | \
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    # Account for fact that we put trailing slashes in our PATH walk.
++case $as_dir in #((
++  ./ | /[cC]/* | \
+   /etc/* | /usr/sbin/* | /usr/etc/* | /sbin/* | /usr/afsws/bin/* | \
+   ?:[\\/]os2[\\/]install[\\/]* | ?:[\\/]OS2[\\/]INSTALL[\\/]* | \
+   /usr/ucb/* ) ;;
+@@ -4153,13 +5028,13 @@
+     # by default.
+     for ac_prog in ginstall scoinst install; do
+       for ac_exec_ext in '' $ac_executable_extensions; do
+-	if as_fn_executable_p "$as_dir/$ac_prog$ac_exec_ext"; then
++	if as_fn_executable_p "$as_dir$ac_prog$ac_exec_ext"; then
+ 	  if test $ac_prog = install &&
+-	    grep dspmsg "$as_dir/$ac_prog$ac_exec_ext" >/dev/null 2>&1; then
++	    grep dspmsg "$as_dir$ac_prog$ac_exec_ext" >/dev/null 2>&1; then
+ 	    # AIX install.  It has an incompatible calling convention.
+ 	    :
+ 	  elif test $ac_prog = install &&
+-	    grep pwplus "$as_dir/$ac_prog$ac_exec_ext" >/dev/null 2>&1; then
++	    grep pwplus "$as_dir$ac_prog$ac_exec_ext" >/dev/null 2>&1; then
+ 	    # program-specific install script used by HP pwplus--don't use.
+ 	    :
+ 	  else
+@@ -4167,12 +5042,12 @@
+ 	    echo one > conftest.one
+ 	    echo two > conftest.two
+ 	    mkdir conftest.dir
+-	    if "$as_dir/$ac_prog$ac_exec_ext" -c conftest.one conftest.two "`pwd`/conftest.dir" &&
++	    if "$as_dir$ac_prog$ac_exec_ext" -c conftest.one conftest.two "`pwd`/conftest.dir/" &&
+ 	      test -s conftest.one && test -s conftest.two &&
+ 	      test -s conftest.dir/conftest.one &&
+ 	      test -s conftest.dir/conftest.two
+ 	    then
+-	      ac_cv_path_install="$as_dir/$ac_prog$ac_exec_ext -c"
++	      ac_cv_path_install="$as_dir$ac_prog$ac_exec_ext -c"
+ 	      break 3
+ 	    fi
+ 	  fi
+@@ -4188,7 +5063,7 @@
+ rm -rf conftest.one conftest.two conftest.dir
+ 
+ fi
+-  if test "${ac_cv_path_install+set}" = set; then
++  if test ${ac_cv_path_install+y}; then
+     INSTALL=$ac_cv_path_install
+   else
+     # As a last resort, use the slow shell script.  Don't cache a
+@@ -4198,8 +5073,8 @@
+     INSTALL=$ac_install_sh
+   fi
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $INSTALL" >&5
+-$as_echo "$INSTALL" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $INSTALL" >&5
++printf "%s\n" "$INSTALL" >&6; }
+ 
+ # Use test -z because SunOS4 sh mishandles braces in ${var-val}.
+ # It thinks the first close brace ends the variable substitution.
+@@ -4209,13 +5084,14 @@
+ 
+ test -z "$INSTALL_DATA" && INSTALL_DATA='${INSTALL} -m 644'
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${MAKE-make} sets \$(MAKE)" >&5
+-$as_echo_n "checking whether ${MAKE-make} sets \$(MAKE)... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether ${MAKE-make} sets \$(MAKE)" >&5
++printf %s "checking whether ${MAKE-make} sets \$(MAKE)... " >&6; }
+ set x ${MAKE-make}
+-ac_make=`$as_echo "$2" | sed 's/+/p/g; s/[^a-zA-Z0-9_]/_/g'`
+-if eval \${ac_cv_prog_make_${ac_make}_set+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++ac_make=`printf "%s\n" "$2" | sed 's/+/p/g; s/[^a-zA-Z0-9_]/_/g'`
++if eval test \${ac_cv_prog_make_${ac_make}_set+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   cat >conftest.make <<\_ACEOF
+ SHELL = /bin/sh
+ all:
+@@ -4231,12 +5107,12 @@
+ rm -f conftest.make
+ fi
+ if eval test \$ac_cv_prog_make_${ac_make}_set = yes; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++printf "%s\n" "yes" >&6; }
+   SET_MAKE=
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+   SET_MAKE="MAKE=${MAKE-make}"
+ fi
+ 
+@@ -4253,11 +5129,12 @@
+ do
+   # Extract the first word of "$ac_prog", so it can be a program name with args.
+ set dummy $ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_path_PYTHON+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_path_PYTHON+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   case $PYTHON in
+   [\\/]* | ?:[\\/]*)
+   ac_cv_path_PYTHON="$PYTHON" # Let the user override the test with a path.
+@@ -4267,11 +5144,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_PYTHON="$as_dir/$ac_word$ac_exec_ext"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_path_PYTHON="$as_dir$ac_word$ac_exec_ext"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -4283,11 +5164,11 @@
+ fi
+ PYTHON=$ac_cv_path_PYTHON
+ if test -n "$PYTHON"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
+-$as_echo "$PYTHON" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
++printf "%s\n" "$PYTHON" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -4300,42 +5181,172 @@
+ 
+ 
+   if test "$PYTHON" = :; then
+-      as_fn_error $? "no suitable Python interpreter found" "$LINENO" 5
++        as_fn_error $? "no suitable Python interpreter found" "$LINENO" 5
+   else
+ 
+-
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON version" >&5
+-$as_echo_n "checking for $am_display_PYTHON version... " >&6; }
+-if ${am_cv_python_version+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  am_cv_python_version=`$PYTHON -c "import sys; sys.stdout.write(sys.version[:3])"`
++              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON version" >&5
++printf %s "checking for $am_display_PYTHON version... " >&6; }
++if test ${am_cv_python_version+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  am_cv_python_version=`$PYTHON -c "import sys; print ('%u.%u' % sys.version_info[:2])"`
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_version" >&5
+-$as_echo "$am_cv_python_version" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_version" >&5
++printf "%s\n" "$am_cv_python_version" >&6; }
+   PYTHON_VERSION=$am_cv_python_version
+ 
+ 
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON platform" >&5
++printf %s "checking for $am_display_PYTHON platform... " >&6; }
++if test ${am_cv_python_platform+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  am_cv_python_platform=`$PYTHON -c "import sys; sys.stdout.write(sys.platform)"`
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_platform" >&5
++printf "%s\n" "$am_cv_python_platform" >&6; }
++  PYTHON_PLATFORM=$am_cv_python_platform
+ 
+-  PYTHON_PREFIX='${prefix}'
+ 
+-  PYTHON_EXEC_PREFIX='${exec_prefix}'
++                            if test "x$prefix" = xNONE; then
++    am__usable_prefix=$ac_default_prefix
++  else
++    am__usable_prefix=$prefix
++  fi
+ 
++  # Allow user to request using sys.* values from Python,
++  # instead of the GNU $prefix values.
+ 
++# Check whether --with-python-sys-prefix was given.
++if test ${with_python_sys_prefix+y}
++then :
++  withval=$with_python_sys_prefix; am_use_python_sys=:
++else $as_nop
++  am_use_python_sys=false
++fi
+ 
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON platform" >&5
+-$as_echo_n "checking for $am_display_PYTHON platform... " >&6; }
+-if ${am_cv_python_platform+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  am_cv_python_platform=`$PYTHON -c "import sys; sys.stdout.write(sys.platform)"`
++
++  # Allow user to override whatever the default Python prefix is.
++
++# Check whether --with-python_prefix was given.
++if test ${with_python_prefix+y}
++then :
++  withval=$with_python_prefix; am_python_prefix_subst=$withval
++   am_cv_python_prefix=$withval
++   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for explicit $am_display_PYTHON prefix" >&5
++printf %s "checking for explicit $am_display_PYTHON prefix... " >&6; }
++   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_prefix" >&5
++printf "%s\n" "$am_cv_python_prefix" >&6; }
++else $as_nop
++
++   if $am_use_python_sys; then
++     # using python sys.prefix value, not GNU
++     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for python default $am_display_PYTHON prefix" >&5
++printf %s "checking for python default $am_display_PYTHON prefix... " >&6; }
++if test ${am_cv_python_prefix+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  am_cv_python_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.prefix)"`
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_platform" >&5
+-$as_echo "$am_cv_python_platform" >&6; }
+-  PYTHON_PLATFORM=$am_cv_python_platform
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_prefix" >&5
++printf "%s\n" "$am_cv_python_prefix" >&6; }
+ 
++               case $am_cv_python_prefix in
++     $am__usable_prefix*)
++       am__strip_prefix=`echo "$am__usable_prefix" | sed 's|.|.|g'`
++       am_python_prefix_subst=`echo "$am_cv_python_prefix" | sed "s,^$am__strip_prefix,\\${prefix},"`
++       ;;
++     *)
++       am_python_prefix_subst=$am_cv_python_prefix
++       ;;
++     esac
++   else # using GNU prefix value, not python sys.prefix
++     am_python_prefix_subst='${prefix}'
++     am_python_prefix=$am_python_prefix_subst
++     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GNU default $am_display_PYTHON prefix" >&5
++printf %s "checking for GNU default $am_display_PYTHON prefix... " >&6; }
++     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_python_prefix" >&5
++printf "%s\n" "$am_python_prefix" >&6; }
++   fi
++fi
+ 
+-  # Just factor out some code duplication.
++  # Substituting python_prefix_subst value.
++  PYTHON_PREFIX=$am_python_prefix_subst
++
++
++  # emacs-page Now do it all over again for Python exec_prefix, but with yet
++  # another conditional: fall back to regular prefix if that was specified.
++
++# Check whether --with-python_exec_prefix was given.
++if test ${with_python_exec_prefix+y}
++then :
++  withval=$with_python_exec_prefix; am_python_exec_prefix_subst=$withval
++   am_cv_python_exec_prefix=$withval
++   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for explicit $am_display_PYTHON exec_prefix" >&5
++printf %s "checking for explicit $am_display_PYTHON exec_prefix... " >&6; }
++   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_exec_prefix" >&5
++printf "%s\n" "$am_cv_python_exec_prefix" >&6; }
++else $as_nop
++
++   # no explicit --with-python_exec_prefix, but if
++   # --with-python_prefix was given, use its value for python_exec_prefix too.
++   if test -n "$with_python_prefix"
++then :
++  am_python_exec_prefix_subst=$with_python_prefix
++    am_cv_python_exec_prefix=$with_python_prefix
++    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for python_prefix-given $am_display_PYTHON exec_prefix" >&5
++printf %s "checking for python_prefix-given $am_display_PYTHON exec_prefix... " >&6; }
++    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_exec_prefix" >&5
++printf "%s\n" "$am_cv_python_exec_prefix" >&6; }
++else $as_nop
++
++    # Set am__usable_exec_prefix whether using GNU or Python values,
++    # since we use that variable for pyexecdir.
++    if test "x$exec_prefix" = xNONE; then
++      am__usable_exec_prefix=$am__usable_prefix
++    else
++      am__usable_exec_prefix=$exec_prefix
++    fi
++    #
++    if $am_use_python_sys; then # using python sys.exec_prefix, not GNU
++      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for python default $am_display_PYTHON exec_prefix" >&5
++printf %s "checking for python default $am_display_PYTHON exec_prefix... " >&6; }
++if test ${am_cv_python_exec_prefix+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  am_cv_python_exec_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.exec_prefix)"`
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_exec_prefix" >&5
++printf "%s\n" "$am_cv_python_exec_prefix" >&6; }
++                        case $am_cv_python_exec_prefix in
++      $am__usable_exec_prefix*)
++        am__strip_prefix=`echo "$am__usable_exec_prefix" | sed 's|.|.|g'`
++        am_python_exec_prefix_subst=`echo "$am_cv_python_exec_prefix" | sed "s,^$am__strip_prefix,\\${exec_prefix},"`
++        ;;
++      *)
++        am_python_exec_prefix_subst=$am_cv_python_exec_prefix
++        ;;
++     esac
++   else # using GNU $exec_prefix, not python sys.exec_prefix
++     am_python_exec_prefix_subst='${exec_prefix}'
++     am_python_exec_prefix=$am_python_exec_prefix_subst
++     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GNU default $am_display_PYTHON exec_prefix" >&5
++printf %s "checking for GNU default $am_display_PYTHON exec_prefix... " >&6; }
++     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_python_exec_prefix" >&5
++printf "%s\n" "$am_python_exec_prefix" >&6; }
++   fi
++fi
++fi
++
++  # Substituting python_exec_prefix_subst.
++  PYTHON_EXEC_PREFIX=$am_python_exec_prefix_subst
++
++
++  # Factor out some code duplication into this shell variable.
+   am_python_setup_sysconfig="\
+ import sys
+ # Prefer sysconfig over distutils.sysconfig, for better compatibility
+@@ -4356,106 +5367,104 @@
+     pass"
+ 
+ 
+-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON script directory" >&5
+-$as_echo_n "checking for $am_display_PYTHON script directory... " >&6; }
+-if ${am_cv_python_pythondir+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test "x$prefix" = xNONE
+-     then
+-       am_py_prefix=$ac_default_prefix
+-     else
+-       am_py_prefix=$prefix
+-     fi
+-     am_cv_python_pythondir=`$PYTHON -c "
++              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON script directory (pythondir)" >&5
++printf %s "checking for $am_display_PYTHON script directory (pythondir)... " >&6; }
++if test ${am_cv_python_pythondir+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test "x$am_cv_python_prefix" = x; then
++     am_py_prefix=$am__usable_prefix
++   else
++     am_py_prefix=$am_cv_python_prefix
++   fi
++   am_cv_python_pythondir=`$PYTHON -c "
+ $am_python_setup_sysconfig
+ if can_use_sysconfig:
+-    sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
++  sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
+ else:
+-    from distutils import sysconfig
+-    sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
++  from distutils import sysconfig
++  sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
+ sys.stdout.write(sitedir)"`
+-     case $am_cv_python_pythondir in
+-     $am_py_prefix*)
+-       am__strip_prefix=`echo "$am_py_prefix" | sed 's|.|.|g'`
+-       am_cv_python_pythondir=`echo "$am_cv_python_pythondir" | sed "s,^$am__strip_prefix,$PYTHON_PREFIX,"`
+-       ;;
+-     *)
+-       case $am_py_prefix in
+-         /usr|/System*) ;;
+-         *)
+-	  am_cv_python_pythondir=$PYTHON_PREFIX/lib/python$PYTHON_VERSION/site-packages
+-	  ;;
+-       esac
+-       ;;
++   #
++   case $am_cv_python_pythondir in
++   $am_py_prefix*)
++     am__strip_prefix=`echo "$am_py_prefix" | sed 's|.|.|g'`
++     am_cv_python_pythondir=`echo "$am_cv_python_pythondir" | sed "s,^$am__strip_prefix,\\${PYTHON_PREFIX},"`
++     ;;
++   *)
++     case $am_py_prefix in
++       /usr|/System*) ;;
++       *) am_cv_python_pythondir="\${PYTHON_PREFIX}/lib/python$PYTHON_VERSION/site-packages"
++          ;;
+      esac
++     ;;
++   esac
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_pythondir" >&5
+-$as_echo "$am_cv_python_pythondir" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_pythondir" >&5
++printf "%s\n" "$am_cv_python_pythondir" >&6; }
+   pythondir=$am_cv_python_pythondir
+ 
+ 
++          pkgpythondir=\${pythondir}/$PACKAGE
+ 
+-  pkgpythondir=\${pythondir}/$PACKAGE
+ 
+-
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON extension module directory" >&5
+-$as_echo_n "checking for $am_display_PYTHON extension module directory... " >&6; }
+-if ${am_cv_python_pyexecdir+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test "x$exec_prefix" = xNONE
+-     then
+-       am_py_exec_prefix=$am_py_prefix
+-     else
+-       am_py_exec_prefix=$exec_prefix
+-     fi
+-     am_cv_python_pyexecdir=`$PYTHON -c "
++          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON extension module directory (pyexecdir)" >&5
++printf %s "checking for $am_display_PYTHON extension module directory (pyexecdir)... " >&6; }
++if test ${am_cv_python_pyexecdir+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test "x$am_cv_python_exec_prefix" = x; then
++     am_py_exec_prefix=$am__usable_exec_prefix
++   else
++     am_py_exec_prefix=$am_cv_python_exec_prefix
++   fi
++   am_cv_python_pyexecdir=`$PYTHON -c "
+ $am_python_setup_sysconfig
+ if can_use_sysconfig:
+-    sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_prefix'})
++  sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_exec_prefix'})
+ else:
+-    from distutils import sysconfig
+-    sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_prefix')
++  from distutils import sysconfig
++  sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_exec_prefix')
+ sys.stdout.write(sitedir)"`
+-     case $am_cv_python_pyexecdir in
+-     $am_py_exec_prefix*)
+-       am__strip_prefix=`echo "$am_py_exec_prefix" | sed 's|.|.|g'`
+-       am_cv_python_pyexecdir=`echo "$am_cv_python_pyexecdir" | sed "s,^$am__strip_prefix,$PYTHON_EXEC_PREFIX,"`
+-       ;;
+-     *)
+-       case $am_py_exec_prefix in
+-         /usr|/System*) ;;
+-         *)
+-	   am_cv_python_pyexecdir=$PYTHON_EXEC_PREFIX/lib/python$PYTHON_VERSION/site-packages
+-	   ;;
+-       esac
+-       ;;
++   #
++   case $am_cv_python_pyexecdir in
++   $am_py_exec_prefix*)
++     am__strip_prefix=`echo "$am_py_exec_prefix" | sed 's|.|.|g'`
++     am_cv_python_pyexecdir=`echo "$am_cv_python_pyexecdir" | sed "s,^$am__strip_prefix,\\${PYTHON_EXEC_PREFIX},"`
++     ;;
++   *)
++     case $am_py_exec_prefix in
++       /usr|/System*) ;;
++       *) am_cv_python_pyexecdir="\${PYTHON_EXEC_PREFIX}/lib/python$PYTHON_VERSION/site-packages"
++          ;;
+      esac
++     ;;
++   esac
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_pyexecdir" >&5
+-$as_echo "$am_cv_python_pyexecdir" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_pyexecdir" >&5
++printf "%s\n" "$am_cv_python_pyexecdir" >&6; }
+   pyexecdir=$am_cv_python_pyexecdir
+ 
+ 
++      pkgpyexecdir=\${pyexecdir}/$PACKAGE
+ 
+-  pkgpyexecdir=\${pyexecdir}/$PACKAGE
+ 
+ 
+-
+   fi
+ 
+ 
+-
+ # Extract the first word of "pkg-config", so it can be a program name with args.
+ set dummy pkg-config; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_path_PKG_CONFIG+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_path_PKG_CONFIG+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   case $PKG_CONFIG in
+   [\\/]* | ?:[\\/]*)
+   ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
+@@ -4465,11 +5474,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_path_PKG_CONFIG="$as_dir$ac_word$ac_exec_ext"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -4482,11 +5495,11 @@
+ fi
+ PKG_CONFIG=$ac_cv_path_PKG_CONFIG
+ if test -n "$PKG_CONFIG"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
+-$as_echo "$PKG_CONFIG" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
++printf "%s\n" "$PKG_CONFIG" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -4496,11 +5509,12 @@
+ if test "$cross_compiling" = yes; then
+   # Extract the first word of "omniidl", so it can be a program name with args.
+ set dummy omniidl; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_path_OMNIIDL+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_path_OMNIIDL+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   case $OMNIIDL in
+   [\\/]* | ?:[\\/]*)
+   ac_cv_path_OMNIIDL="$OMNIIDL" # Let the user override the test with a path.
+@@ -4510,11 +5524,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_OMNIIDL="$as_dir/$ac_word$ac_exec_ext"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_path_OMNIIDL="$as_dir$ac_word$ac_exec_ext"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -4527,11 +5545,11 @@
+ fi
+ OMNIIDL=$ac_cv_path_OMNIIDL
+ if test -n "$OMNIIDL"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OMNIIDL" >&5
+-$as_echo "$OMNIIDL" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OMNIIDL" >&5
++printf "%s\n" "$OMNIIDL" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -4541,11 +5559,12 @@
+ 
+   # Extract the first word of "omkdepend", so it can be a program name with args.
+ set dummy omkdepend; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_path_OMKDEPEND+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_path_OMKDEPEND+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   case $OMKDEPEND in
+   [\\/]* | ?:[\\/]*)
+   ac_cv_path_OMKDEPEND="$OMKDEPEND" # Let the user override the test with a path.
+@@ -4555,11 +5574,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_OMKDEPEND="$as_dir/$ac_word$ac_exec_ext"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_path_OMKDEPEND="$as_dir$ac_word$ac_exec_ext"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -4572,11 +5595,11 @@
+ fi
+ OMKDEPEND=$ac_cv_path_OMKDEPEND
+ if test -n "$OMKDEPEND"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OMKDEPEND" >&5
+-$as_echo "$OMKDEPEND" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OMKDEPEND" >&5
++printf "%s\n" "$OMKDEPEND" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -4610,11 +5633,12 @@
+ 	if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_path_PKG_CONFIG+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_path_PKG_CONFIG+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   case $PKG_CONFIG in
+   [\\/]* | ?:[\\/]*)
+   ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
+@@ -4624,11 +5648,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_path_PKG_CONFIG="$as_dir$ac_word$ac_exec_ext"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -4640,11 +5668,11 @@
+ fi
+ PKG_CONFIG=$ac_cv_path_PKG_CONFIG
+ if test -n "$PKG_CONFIG"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
+-$as_echo "$PKG_CONFIG" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
++printf "%s\n" "$PKG_CONFIG" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+ 
+@@ -4653,11 +5681,12 @@
+   ac_pt_PKG_CONFIG=$PKG_CONFIG
+   # Extract the first word of "pkg-config", so it can be a program name with args.
+ set dummy pkg-config; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_path_ac_pt_PKG_CONFIG+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_path_ac_pt_PKG_CONFIG+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   case $ac_pt_PKG_CONFIG in
+   [\\/]* | ?:[\\/]*)
+   ac_cv_path_ac_pt_PKG_CONFIG="$ac_pt_PKG_CONFIG" # Let the user override the test with a path.
+@@ -4667,11 +5696,15 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir$ac_word$ac_exec_ext"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+ done
+@@ -4683,11 +5716,11 @@
+ fi
+ ac_pt_PKG_CONFIG=$ac_cv_path_ac_pt_PKG_CONFIG
+ if test -n "$ac_pt_PKG_CONFIG"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
+-$as_echo "$ac_pt_PKG_CONFIG" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
++printf "%s\n" "$ac_pt_PKG_CONFIG" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ fi
+ 
+   if test "x$ac_pt_PKG_CONFIG" = x; then
+@@ -4695,8 +5728,8 @@
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     PKG_CONFIG=$ac_pt_PKG_CONFIG
+@@ -4708,34 +5741,36 @@
+ fi
+ if test -n "$PKG_CONFIG"; then
+ 	_pkg_min_version=0.9.0
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
+-$as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
++	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
++printf %s "checking pkg-config is at least version $_pkg_min_version... " >&6; }
+ 	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then
+-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
++		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++printf "%s\n" "yes" >&6; }
+ 	else
+-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ 		PKG_CONFIG=""
+ 	fi
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenSSL root" >&5
+-$as_echo_n "checking for OpenSSL root... " >&6; }
+-if ${omni_cv_openssl_root+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OpenSSL root" >&5
++printf %s "checking for OpenSSL root... " >&6; }
++if test ${omni_cv_openssl_root+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+ # Check whether --with-openssl was given.
+-if test "${with_openssl+set}" = set; then :
++if test ${with_openssl+y}
++then :
+   withval=$with_openssl; omni_cv_openssl_root=$withval
+-else
++else $as_nop
+   omni_cv_openssl_root=no
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_openssl_root" >&5
+-$as_echo "$omni_cv_openssl_root" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_openssl_root" >&5
++printf "%s\n" "$omni_cv_openssl_root" >&6; }
+ 
+ 
+ if test "$omni_cv_openssl_root" = "no"; then
+@@ -4763,17 +5798,17 @@
+     if test "$do_pkg_config" = "yes"; then
+ 
+ pkg_failed=no
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for OPENSSL" >&5
+-$as_echo_n "checking for OPENSSL... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OPENSSL" >&5
++printf %s "checking for OPENSSL... " >&6; }
+ 
+ if test -n "$OPENSSL_CFLAGS"; then
+     pkg_cv_OPENSSL_CFLAGS="$OPENSSL_CFLAGS"
+  elif test -n "$PKG_CONFIG"; then
+     if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl\""; } >&5
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl\""; } >&5
+   ($PKG_CONFIG --exists --print-errors "openssl") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+   pkg_cv_OPENSSL_CFLAGS=`$PKG_CONFIG --cflags "openssl" 2>/dev/null`
+ 		      test "x$?" != "x0" && pkg_failed=yes
+@@ -4787,10 +5822,10 @@
+     pkg_cv_OPENSSL_LIBS="$OPENSSL_LIBS"
+  elif test -n "$PKG_CONFIG"; then
+     if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl\""; } >&5
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl\""; } >&5
+   ($PKG_CONFIG --exists --print-errors "openssl") 2>&5
+   ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+   pkg_cv_OPENSSL_LIBS=`$PKG_CONFIG --libs "openssl" 2>/dev/null`
+ 		      test "x$?" != "x0" && pkg_failed=yes
+@@ -4804,8 +5839,8 @@
+ 
+ 
+ if test $pkg_failed = yes; then
+-   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++   	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ 
+ if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+         _pkg_short_errors_supported=yes
+@@ -4822,14 +5857,14 @@
+ 
+ 	open_ssl_pkgconfig="no"
+ elif test $pkg_failed = untried; then
+-     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
++     	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
+ 	open_ssl_pkgconfig="no"
+ else
+ 	OPENSSL_CFLAGS=$pkg_cv_OPENSSL_CFLAGS
+ 	OPENSSL_LIBS=$pkg_cv_OPENSSL_LIBS
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++printf "%s\n" "yes" >&6; }
+ 	open_ssl_root=`$PKG_CONFIG --variable=prefix openssl`
+            open_ssl_cppflags="$OPENSSL_CFLAGS"
+            open_ssl_lib="$OPENSSL_LIBS"
+@@ -4894,481 +5929,137 @@
+ 
+ 
+ 
+-ac_ext=cpp
+-ac_cpp='$CXXCPP $CPPFLAGS'
+-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to run the C++ preprocessor" >&5
+-$as_echo_n "checking how to run the C++ preprocessor... " >&6; }
+-if test -z "$CXXCPP"; then
+-  if ${ac_cv_prog_CXXCPP+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-      # Double quotes because CXXCPP needs to be expanded
+-    for CXXCPP in "$CXX -E" "/lib/cpp"
+-    do
+-      ac_preproc_ok=false
+-for ac_cxx_preproc_warn_flag in '' yes
++ac_header= ac_cache=
++for ac_item in $ac_header_cxx_list
+ do
+-  # Use a header file that comes with gcc, so configuring glibc
+-  # with a fresh cross-compiler works.
+-  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+-  # <limits.h> exists even on freestanding compilers.
+-  # On the NeXT, cc -E runs the code through the compiler's parser,
+-  # not just through cpp. "Syntax error" is here to catch this case.
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#ifdef __STDC__
+-# include <limits.h>
+-#else
+-# include <assert.h>
+-#endif
+-		     Syntax error
+-_ACEOF
+-if ac_fn_cxx_try_cpp "$LINENO"; then :
+-
+-else
+-  # Broken: fails on valid input.
+-continue
+-fi
+-rm -f conftest.err conftest.i conftest.$ac_ext
+-
+-  # OK, works on sane cases.  Now check whether nonexistent headers
+-  # can be detected and how.
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <ac_nonexistent.h>
+-_ACEOF
+-if ac_fn_cxx_try_cpp "$LINENO"; then :
+-  # Broken: success on invalid input.
+-continue
+-else
+-  # Passes both tests.
+-ac_preproc_ok=:
+-break
+-fi
+-rm -f conftest.err conftest.i conftest.$ac_ext
+-
++  if test $ac_cache; then
++    ac_fn_cxx_check_header_compile "$LINENO" $ac_header ac_cv_header_$ac_cache "$ac_includes_default"
++    if eval test \"x\$ac_cv_header_$ac_cache\" = xyes; then
++      printf "%s\n" "#define $ac_item 1" >> confdefs.h
++    fi
++    ac_header= ac_cache=
++  elif test $ac_header; then
++    ac_cache=$ac_item
++  else
++    ac_header=$ac_item
++  fi
+ done
+-# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
+-rm -f conftest.i conftest.err conftest.$ac_ext
+-if $ac_preproc_ok; then :
+-  break
+-fi
+ 
+-    done
+-    ac_cv_prog_CXXCPP=$CXXCPP
+ 
+-fi
+-  CXXCPP=$ac_cv_prog_CXXCPP
+-else
+-  ac_cv_prog_CXXCPP=$CXXCPP
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $CXXCPP" >&5
+-$as_echo "$CXXCPP" >&6; }
+-ac_preproc_ok=false
+-for ac_cxx_preproc_warn_flag in '' yes
+-do
+-  # Use a header file that comes with gcc, so configuring glibc
+-  # with a fresh cross-compiler works.
+-  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+-  # <limits.h> exists even on freestanding compilers.
+-  # On the NeXT, cc -E runs the code through the compiler's parser,
+-  # not just through cpp. "Syntax error" is here to catch this case.
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#ifdef __STDC__
+-# include <limits.h>
+-#else
+-# include <assert.h>
+-#endif
+-		     Syntax error
+-_ACEOF
+-if ac_fn_cxx_try_cpp "$LINENO"; then :
+ 
+-else
+-  # Broken: fails on valid input.
+-continue
+-fi
+-rm -f conftest.err conftest.i conftest.$ac_ext
+ 
+-  # OK, works on sane cases.  Now check whether nonexistent headers
+-  # can be detected and how.
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <ac_nonexistent.h>
+-_ACEOF
+-if ac_fn_cxx_try_cpp "$LINENO"; then :
+-  # Broken: success on invalid input.
+-continue
+-else
+-  # Passes both tests.
+-ac_preproc_ok=:
+-break
+-fi
+-rm -f conftest.err conftest.i conftest.$ac_ext
+ 
+-done
+-# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
+-rm -f conftest.i conftest.err conftest.$ac_ext
+-if $ac_preproc_ok; then :
+ 
+-else
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "C++ preprocessor \"$CXXCPP\" fails sanity check
+-See \`config.log' for more details" "$LINENO" 5; }
+-fi
+ 
+-ac_ext=cpp
+-ac_cpp='$CXXCPP $CPPFLAGS'
+-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+ 
++if test $ac_cv_header_stdlib_h = yes && test $ac_cv_header_string_h = yes
++then :
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for grep that handles long lines and -e" >&5
+-$as_echo_n "checking for grep that handles long lines and -e... " >&6; }
+-if ${ac_cv_path_GREP+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -z "$GREP"; then
+-  ac_path_GREP_found=false
+-  # Loop through the user's path and test for each of PROGNAME-LIST
+-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_prog in grep ggrep; do
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-      ac_path_GREP="$as_dir/$ac_prog$ac_exec_ext"
+-      as_fn_executable_p "$ac_path_GREP" || continue
+-# Check for GNU ac_path_GREP and select it if it is found.
+-  # Check for GNU $ac_path_GREP
+-case `"$ac_path_GREP" --version 2>&1` in
+-*GNU*)
+-  ac_cv_path_GREP="$ac_path_GREP" ac_path_GREP_found=:;;
+-*)
+-  ac_count=0
+-  $as_echo_n 0123456789 >"conftest.in"
+-  while :
+-  do
+-    cat "conftest.in" "conftest.in" >"conftest.tmp"
+-    mv "conftest.tmp" "conftest.in"
+-    cp "conftest.in" "conftest.nl"
+-    $as_echo 'GREP' >> "conftest.nl"
+-    "$ac_path_GREP" -e 'GREP$' -e '-(cannot match)-' < "conftest.nl" >"conftest.out" 2>/dev/null || break
+-    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+-    as_fn_arith $ac_count + 1 && ac_count=$as_val
+-    if test $ac_count -gt ${ac_path_GREP_max-0}; then
+-      # Best one so far, save it but keep looking for a better one
+-      ac_cv_path_GREP="$ac_path_GREP"
+-      ac_path_GREP_max=$ac_count
+-    fi
+-    # 10*(2^10) chars as input seems more than enough
+-    test $ac_count -gt 10 && break
+-  done
+-  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+-esac
++printf "%s\n" "#define STDC_HEADERS 1" >>confdefs.h
+ 
+-      $ac_path_GREP_found && break 3
+-    done
+-  done
+-  done
+-IFS=$as_save_IFS
+-  if test -z "$ac_cv_path_GREP"; then
+-    as_fn_error $? "no acceptable grep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
+-  fi
+-else
+-  ac_cv_path_GREP=$GREP
+ fi
++ac_fn_cxx_check_header_compile "$LINENO" "errno.h" "ac_cv_header_errno_h" "$ac_includes_default"
++if test "x$ac_cv_header_errno_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_ERRNO_H 1" >>confdefs.h
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_GREP" >&5
+-$as_echo "$ac_cv_path_GREP" >&6; }
+- GREP="$ac_cv_path_GREP"
++ac_fn_cxx_check_header_compile "$LINENO" "fcntl.h" "ac_cv_header_fcntl_h" "$ac_includes_default"
++if test "x$ac_cv_header_fcntl_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_FCNTL_H 1" >>confdefs.h
+ 
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for egrep" >&5
+-$as_echo_n "checking for egrep... " >&6; }
+-if ${ac_cv_path_EGREP+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if echo a | $GREP -E '(a|b)' >/dev/null 2>&1
+-   then ac_cv_path_EGREP="$GREP -E"
+-   else
+-     if test -z "$EGREP"; then
+-  ac_path_EGREP_found=false
+-  # Loop through the user's path and test for each of PROGNAME-LIST
+-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_prog in egrep; do
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-      ac_path_EGREP="$as_dir/$ac_prog$ac_exec_ext"
+-      as_fn_executable_p "$ac_path_EGREP" || continue
+-# Check for GNU ac_path_EGREP and select it if it is found.
+-  # Check for GNU $ac_path_EGREP
+-case `"$ac_path_EGREP" --version 2>&1` in
+-*GNU*)
+-  ac_cv_path_EGREP="$ac_path_EGREP" ac_path_EGREP_found=:;;
+-*)
+-  ac_count=0
+-  $as_echo_n 0123456789 >"conftest.in"
+-  while :
+-  do
+-    cat "conftest.in" "conftest.in" >"conftest.tmp"
+-    mv "conftest.tmp" "conftest.in"
+-    cp "conftest.in" "conftest.nl"
+-    $as_echo 'EGREP' >> "conftest.nl"
+-    "$ac_path_EGREP" 'EGREP$' < "conftest.nl" >"conftest.out" 2>/dev/null || break
+-    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+-    as_fn_arith $ac_count + 1 && ac_count=$as_val
+-    if test $ac_count -gt ${ac_path_EGREP_max-0}; then
+-      # Best one so far, save it but keep looking for a better one
+-      ac_cv_path_EGREP="$ac_path_EGREP"
+-      ac_path_EGREP_max=$ac_count
+-    fi
+-    # 10*(2^10) chars as input seems more than enough
+-    test $ac_count -gt 10 && break
+-  done
+-  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+-esac
+-
+-      $ac_path_EGREP_found && break 3
+-    done
+-  done
+-  done
+-IFS=$as_save_IFS
+-  if test -z "$ac_cv_path_EGREP"; then
+-    as_fn_error $? "no acceptable egrep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
+-  fi
+-else
+-  ac_cv_path_EGREP=$EGREP
+ fi
++ac_fn_cxx_check_header_compile "$LINENO" "netdb.h" "ac_cv_header_netdb_h" "$ac_includes_default"
++if test "x$ac_cv_header_netdb_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_NETDB_H 1" >>confdefs.h
+ 
+-   fi
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_EGREP" >&5
+-$as_echo "$ac_cv_path_EGREP" >&6; }
+- EGREP="$ac_cv_path_EGREP"
++ac_fn_cxx_check_header_compile "$LINENO" "signal.h" "ac_cv_header_signal_h" "$ac_includes_default"
++if test "x$ac_cv_header_signal_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_SIGNAL_H 1" >>confdefs.h
+ 
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
+-$as_echo_n "checking for ANSI C header files... " >&6; }
+-if ${ac_cv_header_stdc+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <stdlib.h>
+-#include <stdarg.h>
+-#include <string.h>
+-#include <float.h>
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
+-  ac_cv_header_stdc=yes
+-else
+-  ac_cv_header_stdc=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++ac_fn_cxx_check_header_compile "$LINENO" "stdlib.h" "ac_cv_header_stdlib_h" "$ac_includes_default"
++if test "x$ac_cv_header_stdlib_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_STDLIB_H 1" >>confdefs.h
+ 
+-if test $ac_cv_header_stdc = yes; then
+-  # SunOS 4.x string.h does not declare mem*, contrary to ANSI.
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <string.h>
+-
+-_ACEOF
+-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+-  $EGREP "memchr" >/dev/null 2>&1; then :
+-
+-else
+-  ac_cv_header_stdc=no
+ fi
+-rm -f conftest*
++ac_fn_cxx_check_header_compile "$LINENO" "string.h" "ac_cv_header_string_h" "$ac_includes_default"
++if test "x$ac_cv_header_string_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRING_H 1" >>confdefs.h
+ 
+ fi
++ac_fn_cxx_check_header_compile "$LINENO" "strings.h" "ac_cv_header_strings_h" "$ac_includes_default"
++if test "x$ac_cv_header_strings_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRINGS_H 1" >>confdefs.h
+ 
+-if test $ac_cv_header_stdc = yes; then
+-  # ISC 2.0.2 stdlib.h does not declare free, contrary to ANSI.
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <stdlib.h>
+-
+-_ACEOF
+-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+-  $EGREP "free" >/dev/null 2>&1; then :
+-
+-else
+-  ac_cv_header_stdc=no
+ fi
+-rm -f conftest*
+ 
+-fi
++ac_fn_cxx_check_header_compile "$LINENO" "unistd.h" "ac_cv_header_unistd_h" "$ac_includes_default"
++if test "x$ac_cv_header_unistd_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_UNISTD_H 1" >>confdefs.h
+ 
+-if test $ac_cv_header_stdc = yes; then
+-  # /bin/cc in Irix-4.0.5 gets non-ANSI ctype macros unless using -ansi.
+-  if test "$cross_compiling" = yes; then :
+-  :
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <ctype.h>
+-#include <stdlib.h>
+-#if ((' ' & 0x0FF) == 0x020)
+-# define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+-# define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
+-#else
+-# define ISLOWER(c) \
+-		   (('a' <= (c) && (c) <= 'i') \
+-		     || ('j' <= (c) && (c) <= 'r') \
+-		     || ('s' <= (c) && (c) <= 'z'))
+-# define TOUPPER(c) (ISLOWER(c) ? ((c) | 0x40) : (c))
+-#endif
+-
+-#define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+-int
+-main ()
+-{
+-  int i;
+-  for (i = 0; i < 256; i++)
+-    if (XOR (islower (i), ISLOWER (i))
+-	|| toupper (i) != TOUPPER (i))
+-      return 2;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_cxx_try_run "$LINENO"; then :
+-
+-else
+-  ac_cv_header_stdc=no
+ fi
+-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
+-fi
++ac_fn_cxx_check_header_compile "$LINENO" "nan.h" "ac_cv_header_nan_h" "$ac_includes_default"
++if test "x$ac_cv_header_nan_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_NAN_H 1" >>confdefs.h
+ 
+ fi
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_stdc" >&5
+-$as_echo "$ac_cv_header_stdc" >&6; }
+-if test $ac_cv_header_stdc = yes; then
++ac_fn_cxx_check_header_compile "$LINENO" "sys/if.h" "ac_cv_header_sys_if_h" "$ac_includes_default"
++if test "x$ac_cv_header_sys_if_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_SYS_IF_H 1" >>confdefs.h
+ 
+-$as_echo "#define STDC_HEADERS 1" >>confdefs.h
+-
+ fi
++ac_fn_cxx_check_header_compile "$LINENO" "sys/ioctl.h" "ac_cv_header_sys_ioctl_h" "$ac_includes_default"
++if test "x$ac_cv_header_sys_ioctl_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_SYS_IOCTL_H 1" >>confdefs.h
+ 
+-# On IRIX 5.3, sys/types and inttypes.h are conflicting.
+-for ac_header in sys/types.h sys/stat.h stdlib.h string.h memory.h strings.h \
+-		  inttypes.h stdint.h unistd.h
+-do :
+-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+-ac_fn_cxx_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
+-"
+-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+-_ACEOF
+-
+ fi
++ac_fn_cxx_check_header_compile "$LINENO" "sys/param.h" "ac_cv_header_sys_param_h" "$ac_includes_default"
++if test "x$ac_cv_header_sys_param_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_SYS_PARAM_H 1" >>confdefs.h
+ 
+-done
+-
+-
+-for ac_header in errno.h fcntl.h netdb.h signal.h stdlib.h string.h strings.h
+-do :
+-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+-ac_fn_cxx_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+-_ACEOF
+-
+ fi
++ac_fn_cxx_check_header_compile "$LINENO" "sys/time.h" "ac_cv_header_sys_time_h" "$ac_includes_default"
++if test "x$ac_cv_header_sys_time_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_SYS_TIME_H 1" >>confdefs.h
+ 
+-done
+-
+-for ac_header in unistd.h nan.h sys/if.h sys/ioctl.h sys/param.h sys/time.h
+-do :
+-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+-ac_fn_cxx_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+-_ACEOF
+-
+ fi
+ 
+-done
++ac_fn_cxx_check_header_compile "$LINENO" "sys/poll.h" "ac_cv_header_sys_poll_h" "$ac_includes_default"
++if test "x$ac_cv_header_sys_poll_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_SYS_POLL_H 1" >>confdefs.h
+ 
+-for ac_header in sys/poll.h ifaddrs.h
+-do :
+-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+-ac_fn_cxx_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+-_ACEOF
+-
+ fi
++ac_fn_cxx_check_header_compile "$LINENO" "ifaddrs.h" "ac_cv_header_ifaddrs_h" "$ac_includes_default"
++if test "x$ac_cv_header_ifaddrs_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_IFADDRS_H 1" >>confdefs.h
+ 
+-done
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether time.h and sys/time.h may both be included" >&5
+-$as_echo_n "checking whether time.h and sys/time.h may both be included... " >&6; }
+-if ${ac_cv_header_time+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <sys/types.h>
+-#include <sys/time.h>
+-#include <time.h>
+-
+-int
+-main ()
+-{
+-if ((struct tm *) 0)
+-return 0;
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
+-  ac_cv_header_time=yes
+-else
+-  ac_cv_header_time=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_time" >&5
+-$as_echo "$ac_cv_header_time" >&6; }
+-if test $ac_cv_header_time = yes; then
+ 
+-$as_echo "#define TIME_WITH_SYS_TIME 1" >>confdefs.h
+ 
+-fi
+ 
+ 
+-
+-
+- { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether byte ordering is bigendian" >&5
+-$as_echo_n "checking whether byte ordering is bigendian... " >&6; }
+-if ${ac_cv_c_bigendian+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether byte ordering is bigendian" >&5
++printf %s "checking whether byte ordering is bigendian... " >&6; }
++if test ${ac_cv_c_bigendian+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_cv_c_bigendian=unknown
+     # See if we're dealing with a universal compiler.
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -5379,7 +6070,8 @@
+ 	     typedef int dummy;
+ 
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+ 
+ 	# Check for potential -arch flags.  It is not universal unless
+ 	# there are at least two -arch flags with different values.
+@@ -5403,7 +6095,7 @@
+ 	 fi
+        done
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+     if test $ac_cv_c_bigendian = unknown; then
+       # See if sys/param.h defines the BYTE_ORDER macro.
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -5412,7 +6104,7 @@
+ 	     #include <sys/param.h>
+ 
+ int
+-main ()
++main (void)
+ {
+ #if ! (defined BYTE_ORDER && defined BIG_ENDIAN \
+ 		     && defined LITTLE_ENDIAN && BYTE_ORDER && BIG_ENDIAN \
+@@ -5424,7 +6116,8 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   # It does; now see whether it defined to BIG_ENDIAN or not.
+ 	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+@@ -5432,7 +6125,7 @@
+ 		#include <sys/param.h>
+ 
+ int
+-main ()
++main (void)
+ {
+ #if BYTE_ORDER != BIG_ENDIAN
+ 		 not big endian
+@@ -5442,14 +6135,15 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_c_bigendian=yes
+-else
++else $as_nop
+   ac_cv_c_bigendian=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+     fi
+     if test $ac_cv_c_bigendian = unknown; then
+       # See if <limits.h> defines _LITTLE_ENDIAN or _BIG_ENDIAN (e.g., Solaris).
+@@ -5458,7 +6152,7 @@
+ #include <limits.h>
+ 
+ int
+-main ()
++main (void)
+ {
+ #if ! (defined _LITTLE_ENDIAN || defined _BIG_ENDIAN)
+ 	      bogus endian macros
+@@ -5468,7 +6162,8 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   # It does; now see whether it defined to _BIG_ENDIAN or not.
+ 	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+@@ -5475,7 +6170,7 @@
+ #include <limits.h>
+ 
+ int
+-main ()
++main (void)
+ {
+ #ifndef _BIG_ENDIAN
+ 		 not big endian
+@@ -5485,31 +6180,33 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_c_bigendian=yes
+-else
++else $as_nop
+   ac_cv_c_bigendian=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+     fi
+     if test $ac_cv_c_bigendian = unknown; then
+       # Compile a test program.
+-      if test "$cross_compiling" = yes; then :
++      if test "$cross_compiling" = yes
++then :
+   # Try to guess by grepping values from an object file.
+ 	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-short int ascii_mm[] =
++unsigned short int ascii_mm[] =
+ 		  { 0x4249, 0x4765, 0x6E44, 0x6961, 0x6E53, 0x7953, 0 };
+-		short int ascii_ii[] =
++		unsigned short int ascii_ii[] =
+ 		  { 0x694C, 0x5454, 0x656C, 0x6E45, 0x6944, 0x6E61, 0 };
+ 		int use_ascii (int i) {
+ 		  return ascii_mm[i] + ascii_ii[i];
+ 		}
+-		short int ebcdic_ii[] =
++		unsigned short int ebcdic_ii[] =
+ 		  { 0x89D3, 0xE3E3, 0x8593, 0x95C5, 0x89C4, 0x9581, 0 };
+-		short int ebcdic_mm[] =
++		unsigned short int ebcdic_mm[] =
+ 		  { 0xC2C9, 0xC785, 0x95C4, 0x8981, 0x95E2, 0xA8E2, 0 };
+ 		int use_ebcdic (int i) {
+ 		  return ebcdic_mm[i] + ebcdic_ii[i];
+@@ -5517,7 +6214,7 @@
+ 		extern int foo;
+ 
+ int
+-main ()
++main (void)
+ {
+ return use_ascii (foo) == use_ebcdic (foo);
+   ;
+@@ -5524,7 +6221,8 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   if grep BIGenDianSyS conftest.$ac_objext >/dev/null; then
+ 	      ac_cv_c_bigendian=yes
+ 	    fi
+@@ -5537,13 +6235,13 @@
+ 	      fi
+ 	    fi
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-else
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $ac_includes_default
+ int
+-main ()
++main (void)
+ {
+ 
+ 	     /* Are we little or big endian?  From Harbison&Steele.  */
+@@ -5559,9 +6257,10 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_run "$LINENO"; then :
++if ac_fn_cxx_try_run "$LINENO"
++then :
+   ac_cv_c_bigendian=no
+-else
++else $as_nop
+   ac_cv_c_bigendian=yes
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+@@ -5570,17 +6269,17 @@
+ 
+     fi
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_bigendian" >&5
+-$as_echo "$ac_cv_c_bigendian" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_bigendian" >&5
++printf "%s\n" "$ac_cv_c_bigendian" >&6; }
+  case $ac_cv_c_bigendian in #(
+    yes)
+-     $as_echo "#define WORDS_BIGENDIAN 1" >>confdefs.h
++     printf "%s\n" "#define WORDS_BIGENDIAN 1" >>confdefs.h
+ ;; #(
+    no)
+       ;; #(
+    universal)
+ 
+-$as_echo "#define AC_APPLE_UNIVERSAL_BUILD 1" >>confdefs.h
++printf "%s\n" "#define AC_APPLE_UNIVERSAL_BUILD 1" >>confdefs.h
+ 
+      ;; #(
+    *)
+@@ -5592,17 +6291,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of char" >&5
+-$as_echo_n "checking size of char... " >&6; }
+-if ${ac_cv_sizeof_char+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (char))" "ac_cv_sizeof_char"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of char" >&5
++printf %s "checking size of char... " >&6; }
++if test ${ac_cv_sizeof_char+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (char))" "ac_cv_sizeof_char"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_char" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (char)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5611,14 +6312,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_char" >&5
+-$as_echo "$ac_cv_sizeof_char" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_char" >&5
++printf "%s\n" "$ac_cv_sizeof_char" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_CHAR $ac_cv_sizeof_char
+-_ACEOF
++printf "%s\n" "#define SIZEOF_CHAR $ac_cv_sizeof_char" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5625,17 +6324,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of unsigned char" >&5
+-$as_echo_n "checking size of unsigned char... " >&6; }
+-if ${ac_cv_sizeof_unsigned_char+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (unsigned char))" "ac_cv_sizeof_unsigned_char"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of unsigned char" >&5
++printf %s "checking size of unsigned char... " >&6; }
++if test ${ac_cv_sizeof_unsigned_char+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (unsigned char))" "ac_cv_sizeof_unsigned_char"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_unsigned_char" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (unsigned char)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5644,14 +6345,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_unsigned_char" >&5
+-$as_echo "$ac_cv_sizeof_unsigned_char" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_unsigned_char" >&5
++printf "%s\n" "$ac_cv_sizeof_unsigned_char" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_UNSIGNED_CHAR $ac_cv_sizeof_unsigned_char
+-_ACEOF
++printf "%s\n" "#define SIZEOF_UNSIGNED_CHAR $ac_cv_sizeof_unsigned_char" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5658,17 +6357,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of bool" >&5
+-$as_echo_n "checking size of bool... " >&6; }
+-if ${ac_cv_sizeof_bool+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (bool))" "ac_cv_sizeof_bool"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of bool" >&5
++printf %s "checking size of bool... " >&6; }
++if test ${ac_cv_sizeof_bool+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (bool))" "ac_cv_sizeof_bool"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_bool" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (bool)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5677,14 +6378,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_bool" >&5
+-$as_echo "$ac_cv_sizeof_bool" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_bool" >&5
++printf "%s\n" "$ac_cv_sizeof_bool" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_BOOL $ac_cv_sizeof_bool
+-_ACEOF
++printf "%s\n" "#define SIZEOF_BOOL $ac_cv_sizeof_bool" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5691,17 +6390,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of short" >&5
+-$as_echo_n "checking size of short... " >&6; }
+-if ${ac_cv_sizeof_short+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (short))" "ac_cv_sizeof_short"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of short" >&5
++printf %s "checking size of short... " >&6; }
++if test ${ac_cv_sizeof_short+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (short))" "ac_cv_sizeof_short"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_short" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (short)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5710,14 +6411,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_short" >&5
+-$as_echo "$ac_cv_sizeof_short" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_short" >&5
++printf "%s\n" "$ac_cv_sizeof_short" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_SHORT $ac_cv_sizeof_short
+-_ACEOF
++printf "%s\n" "#define SIZEOF_SHORT $ac_cv_sizeof_short" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5724,17 +6423,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of int" >&5
+-$as_echo_n "checking size of int... " >&6; }
+-if ${ac_cv_sizeof_int+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (int))" "ac_cv_sizeof_int"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of int" >&5
++printf %s "checking size of int... " >&6; }
++if test ${ac_cv_sizeof_int+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (int))" "ac_cv_sizeof_int"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_int" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (int)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5743,14 +6444,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_int" >&5
+-$as_echo "$ac_cv_sizeof_int" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_int" >&5
++printf "%s\n" "$ac_cv_sizeof_int" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_INT $ac_cv_sizeof_int
+-_ACEOF
++printf "%s\n" "#define SIZEOF_INT $ac_cv_sizeof_int" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5757,17 +6456,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of long" >&5
+-$as_echo_n "checking size of long... " >&6; }
+-if ${ac_cv_sizeof_long+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (long))" "ac_cv_sizeof_long"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of long" >&5
++printf %s "checking size of long... " >&6; }
++if test ${ac_cv_sizeof_long+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (long))" "ac_cv_sizeof_long"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_long" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (long)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5776,14 +6477,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long" >&5
+-$as_echo "$ac_cv_sizeof_long" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long" >&5
++printf "%s\n" "$ac_cv_sizeof_long" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_LONG $ac_cv_sizeof_long
+-_ACEOF
++printf "%s\n" "#define SIZEOF_LONG $ac_cv_sizeof_long" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5790,17 +6489,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of long long" >&5
+-$as_echo_n "checking size of long long... " >&6; }
+-if ${ac_cv_sizeof_long_long+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (long long))" "ac_cv_sizeof_long_long"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of long long" >&5
++printf %s "checking size of long long... " >&6; }
++if test ${ac_cv_sizeof_long_long+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (long long))" "ac_cv_sizeof_long_long"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_long_long" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (long long)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5809,14 +6510,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long_long" >&5
+-$as_echo "$ac_cv_sizeof_long_long" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long_long" >&5
++printf "%s\n" "$ac_cv_sizeof_long_long" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_LONG_LONG $ac_cv_sizeof_long_long
+-_ACEOF
++printf "%s\n" "#define SIZEOF_LONG_LONG $ac_cv_sizeof_long_long" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5823,17 +6522,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of float" >&5
+-$as_echo_n "checking size of float... " >&6; }
+-if ${ac_cv_sizeof_float+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (float))" "ac_cv_sizeof_float"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of float" >&5
++printf %s "checking size of float... " >&6; }
++if test ${ac_cv_sizeof_float+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (float))" "ac_cv_sizeof_float"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_float" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (float)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5842,14 +6543,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_float" >&5
+-$as_echo "$ac_cv_sizeof_float" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_float" >&5
++printf "%s\n" "$ac_cv_sizeof_float" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_FLOAT $ac_cv_sizeof_float
+-_ACEOF
++printf "%s\n" "#define SIZEOF_FLOAT $ac_cv_sizeof_float" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5856,17 +6555,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of double" >&5
+-$as_echo_n "checking size of double... " >&6; }
+-if ${ac_cv_sizeof_double+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (double))" "ac_cv_sizeof_double"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of double" >&5
++printf %s "checking size of double... " >&6; }
++if test ${ac_cv_sizeof_double+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (double))" "ac_cv_sizeof_double"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_double" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (double)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5875,14 +6576,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_double" >&5
+-$as_echo "$ac_cv_sizeof_double" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_double" >&5
++printf "%s\n" "$ac_cv_sizeof_double" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_DOUBLE $ac_cv_sizeof_double
+-_ACEOF
++printf "%s\n" "#define SIZEOF_DOUBLE $ac_cv_sizeof_double" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5889,17 +6588,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of long double" >&5
+-$as_echo_n "checking size of long double... " >&6; }
+-if ${ac_cv_sizeof_long_double+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (long double))" "ac_cv_sizeof_long_double"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of long double" >&5
++printf %s "checking size of long double... " >&6; }
++if test ${ac_cv_sizeof_long_double+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (long double))" "ac_cv_sizeof_long_double"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_long_double" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (long double)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5908,14 +6609,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long_double" >&5
+-$as_echo "$ac_cv_sizeof_long_double" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long_double" >&5
++printf "%s\n" "$ac_cv_sizeof_long_double" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_LONG_DOUBLE $ac_cv_sizeof_long_double
+-_ACEOF
++printf "%s\n" "#define SIZEOF_LONG_DOUBLE $ac_cv_sizeof_long_double" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5922,17 +6621,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of wchar_t" >&5
+-$as_echo_n "checking size of wchar_t... " >&6; }
+-if ${ac_cv_sizeof_wchar_t+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (wchar_t))" "ac_cv_sizeof_wchar_t"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of wchar_t" >&5
++printf %s "checking size of wchar_t... " >&6; }
++if test ${ac_cv_sizeof_wchar_t+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (wchar_t))" "ac_cv_sizeof_wchar_t"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_wchar_t" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (wchar_t)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5941,14 +6642,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_wchar_t" >&5
+-$as_echo "$ac_cv_sizeof_wchar_t" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_wchar_t" >&5
++printf "%s\n" "$ac_cv_sizeof_wchar_t" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_WCHAR_T $ac_cv_sizeof_wchar_t
+-_ACEOF
++printf "%s\n" "#define SIZEOF_WCHAR_T $ac_cv_sizeof_wchar_t" >>confdefs.h
+ 
+ 
+ # The cast to long int works around a bug in the HP C Compiler
+@@ -5955,17 +6654,19 @@
+ # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+ # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+ # This bug is HP SR number 8606223364.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of void*" >&5
+-$as_echo_n "checking size of void*... " >&6; }
+-if ${ac_cv_sizeof_voidp+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (void*))" "ac_cv_sizeof_voidp"        "$ac_includes_default"; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of void*" >&5
++printf %s "checking size of void*... " >&6; }
++if test ${ac_cv_sizeof_voidp+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (void*))" "ac_cv_sizeof_voidp"        "$ac_includes_default"
++then :
+ 
+-else
++else $as_nop
+   if test "$ac_cv_type_voidp" = yes; then
+-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot compute sizeof (void*)
+ See \`config.log' for more details" "$LINENO" 5; }
+    else
+@@ -5974,14 +6675,12 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_voidp" >&5
+-$as_echo "$ac_cv_sizeof_voidp" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_voidp" >&5
++printf "%s\n" "$ac_cv_sizeof_voidp" >&6; }
+ 
+ 
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define SIZEOF_VOIDP $ac_cv_sizeof_voidp
+-_ACEOF
++printf "%s\n" "#define SIZEOF_VOIDP $ac_cv_sizeof_voidp" >>confdefs.h
+ 
+ 
+ 
+@@ -5992,11 +6691,10 @@
+ #include <net/if.h>
+ #include <netinet/in.h>
+ "
+-if test "x$ac_cv_type_struct_sockaddr_in6" = xyes; then :
++if test "x$ac_cv_type_struct_sockaddr_in6" = xyes
++then :
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define HAVE_STRUCT_SOCKADDR_IN6 1
+-_ACEOF
++printf "%s\n" "#define HAVE_STRUCT_SOCKADDR_IN6 1" >>confdefs.h
+ 
+ 
+ fi
+@@ -6005,11 +6703,10 @@
+ #include <net/if.h>
+ #include <netinet/in.h>
+ "
+-if test "x$ac_cv_type_struct_sockaddr_storage" = xyes; then :
++if test "x$ac_cv_type_struct_sockaddr_storage" = xyes
++then :
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define HAVE_STRUCT_SOCKADDR_STORAGE 1
+-_ACEOF
++printf "%s\n" "#define HAVE_STRUCT_SOCKADDR_STORAGE 1" >>confdefs.h
+ 
+ 
+ fi
+@@ -6018,11 +6715,10 @@
+ #include <net/if.h>
+ #include <netinet/in.h>
+ "
+-if test "x$ac_cv_type_struct_lifconf" = xyes; then :
++if test "x$ac_cv_type_struct_lifconf" = xyes
++then :
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define HAVE_STRUCT_LIFCONF 1
+-_ACEOF
++printf "%s\n" "#define HAVE_STRUCT_LIFCONF 1" >>confdefs.h
+ 
+ 
+ fi
+@@ -6032,11 +6728,10 @@
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ "
+-if test "x$ac_cv_member_struct_sockaddr_in_sin_len" = xyes; then :
++if test "x$ac_cv_member_struct_sockaddr_in_sin_len" = xyes
++then :
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define HAVE_STRUCT_SOCKADDR_IN_SIN_LEN 1
+-_ACEOF
++printf "%s\n" "#define HAVE_STRUCT_SOCKADDR_IN_SIN_LEN 1" >>confdefs.h
+ 
+ 
+ fi
+@@ -6044,11 +6739,10 @@
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ "
+-if test "x$ac_cv_member_struct_sockaddr_in_sin_zero" = xyes; then :
++if test "x$ac_cv_member_struct_sockaddr_in_sin_zero" = xyes
++then :
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define HAVE_STRUCT_SOCKADDR_IN_SIN_ZERO 1
+-_ACEOF
++printf "%s\n" "#define HAVE_STRUCT_SOCKADDR_IN_SIN_ZERO 1" >>confdefs.h
+ 
+ 
+ fi
+@@ -6056,11 +6750,12 @@
+ 
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler recognizes bool as a built-in type" >&5
+-$as_echo_n "checking whether the compiler recognizes bool as a built-in type... " >&6; }
+-if ${ac_cv_cxx_bool+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler recognizes bool as a built-in type" >&5
++printf %s "checking whether the compiler recognizes bool as a built-in type... " >&6; }
++if test ${ac_cv_cxx_bool+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -6076,7 +6771,7 @@
+ int f(bool x){return 1;}
+ 
+ int
+-main ()
++main (void)
+ {
+ bool b = true; return f(b);
+   ;
+@@ -6083,12 +6778,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_cxx_bool=yes
+-else
++else $as_nop
+   ac_cv_cxx_bool=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6097,19 +6793,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_bool" >&5
+-$as_echo "$ac_cv_cxx_bool" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_bool" >&5
++printf "%s\n" "$ac_cv_cxx_bool" >&6; }
+ if test "$ac_cv_cxx_bool" = yes; then
+ 
+-$as_echo "#define HAVE_BOOL /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_BOOL /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports const_cast<>" >&5
+-$as_echo_n "checking whether the compiler supports const_cast<>... " >&6; }
+-if ${ac_cv_cxx_const_cast+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports const_cast<>" >&5
++printf %s "checking whether the compiler supports const_cast<>... " >&6; }
++if test ${ac_cv_cxx_const_cast+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -6121,7 +6818,7 @@
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ int x = 0;const int& y = x;int& z = const_cast<int&>(y);return z;
+   ;
+@@ -6128,12 +6825,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_cxx_const_cast=yes
+-else
++else $as_nop
+   ac_cv_cxx_const_cast=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6142,19 +6840,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_const_cast" >&5
+-$as_echo "$ac_cv_cxx_const_cast" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_const_cast" >&5
++printf "%s\n" "$ac_cv_cxx_const_cast" >&6; }
+ if test "$ac_cv_cxx_const_cast" = yes; then
+ 
+-$as_echo "#define HAVE_CONST_CAST /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_CONST_CAST /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports dynamic_cast<>" >&5
+-$as_echo_n "checking whether the compiler supports dynamic_cast<>... " >&6; }
+-if ${ac_cv_cxx_dynamic_cast+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports dynamic_cast<>" >&5
++printf %s "checking whether the compiler supports dynamic_cast<>... " >&6; }
++if test ${ac_cv_cxx_dynamic_cast+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -6168,7 +6867,7 @@
+ class Base { public : Base () {} virtual void f () = 0;};
+ class Derived : public Base { public : Derived () {} virtual void f () {} };
+ int
+-main ()
++main (void)
+ {
+ 
+ Derived d; Base& b=d; return dynamic_cast<Derived*>(&b) ? 0 : 1;
+@@ -6176,12 +6875,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_cxx_dynamic_cast=yes
+-else
++else $as_nop
+   ac_cv_cxx_dynamic_cast=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6190,19 +6890,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_dynamic_cast" >&5
+-$as_echo "$ac_cv_cxx_dynamic_cast" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_dynamic_cast" >&5
++printf "%s\n" "$ac_cv_cxx_dynamic_cast" >&6; }
+ if test "$ac_cv_cxx_dynamic_cast" = yes; then
+ 
+-$as_echo "#define HAVE_DYNAMIC_CAST /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_DYNAMIC_CAST /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports reinterpret_cast<>" >&5
+-$as_echo_n "checking whether the compiler supports reinterpret_cast<>... " >&6; }
+-if ${ac_cv_cxx_reinterpret_cast+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports reinterpret_cast<>" >&5
++printf %s "checking whether the compiler supports reinterpret_cast<>... " >&6; }
++if test ${ac_cv_cxx_reinterpret_cast+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -6218,7 +6919,7 @@
+ class Unrelated { public : Unrelated () {} };
+ int g (Unrelated&) { return 0; }
+ int
+-main ()
++main (void)
+ {
+ 
+ Derived d;Base& b=d;Unrelated& e=reinterpret_cast<Unrelated&>(b);return g(e);
+@@ -6226,12 +6927,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_cxx_reinterpret_cast=yes
+-else
++else $as_nop
+   ac_cv_cxx_reinterpret_cast=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6240,19 +6942,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_reinterpret_cast" >&5
+-$as_echo "$ac_cv_cxx_reinterpret_cast" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_reinterpret_cast" >&5
++printf "%s\n" "$ac_cv_cxx_reinterpret_cast" >&6; }
+ if test "$ac_cv_cxx_reinterpret_cast" = yes; then
+ 
+-$as_echo "#define HAVE_REINTERPRET_CAST /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_REINTERPRET_CAST /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler implements namespaces" >&5
+-$as_echo_n "checking whether the compiler implements namespaces... " >&6; }
+-if ${ac_cv_cxx_namespaces+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler implements namespaces" >&5
++printf %s "checking whether the compiler implements namespaces... " >&6; }
++if test ${ac_cv_cxx_namespaces+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -6264,7 +6967,7 @@
+ /* end confdefs.h.  */
+ namespace Outer { namespace Inner { int i = 0; }}
+ int
+-main ()
++main (void)
+ {
+ using namespace Outer::Inner; return i;
+   ;
+@@ -6271,12 +6974,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_cxx_namespaces=yes
+-else
++else $as_nop
+   ac_cv_cxx_namespaces=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6285,19 +6989,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_namespaces" >&5
+-$as_echo "$ac_cv_cxx_namespaces" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_namespaces" >&5
++printf "%s\n" "$ac_cv_cxx_namespaces" >&6; }
+ if test "$ac_cv_cxx_namespaces" = yes; then
+ 
+-$as_echo "#define HAVE_NAMESPACES /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_NAMESPACES /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports ISO C++ standard library" >&5
+-$as_echo_n "checking whether the compiler supports ISO C++ standard library... " >&6; }
+-if ${ac_cv_cxx_have_std+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports ISO C++ standard library" >&5
++printf %s "checking whether the compiler supports ISO C++ standard library... " >&6; }
++if test ${ac_cv_cxx_have_std+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+ 
+  ac_ext=cpp
+@@ -6316,7 +7021,7 @@
+ using namespace std;
+ #endif
+ int
+-main ()
++main (void)
+ {
+ return 0;
+   ;
+@@ -6323,12 +7028,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_cxx_have_std=yes
+-else
++else $as_nop
+   ac_cv_cxx_have_std=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6337,19 +7043,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_have_std" >&5
+-$as_echo "$ac_cv_cxx_have_std" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_have_std" >&5
++printf "%s\n" "$ac_cv_cxx_have_std" >&6; }
+ if test "$ac_cv_cxx_have_std" = yes; then
+ 
+-$as_echo "#define HAVE_STD /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_STD /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports member constants" >&5
+-$as_echo_n "checking whether the compiler supports member constants... " >&6; }
+-if ${ac_cv_cxx_member_constants+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports member constants" >&5
++printf %s "checking whether the compiler supports member constants... " >&6; }
++if test ${ac_cv_cxx_member_constants+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -6361,7 +7068,7 @@
+ /* end confdefs.h.  */
+ class C {public: static const int i = 0;}; const int C::i;
+ int
+-main ()
++main (void)
+ {
+ return C::i;
+   ;
+@@ -6368,12 +7075,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_cxx_member_constants=yes
+-else
++else $as_nop
+   ac_cv_cxx_member_constants=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6382,20 +7090,21 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_member_constants" >&5
+-$as_echo "$ac_cv_cxx_member_constants" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_member_constants" >&5
++printf "%s\n" "$ac_cv_cxx_member_constants" >&6; }
+ if test "$ac_cv_cxx_member_constants" = yes; then
+ 
+-$as_echo "#define HAVE_MEMBER_CONSTANTS /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_MEMBER_CONSTANTS /**/" >>confdefs.h
+ 
+ fi
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports exceptions" >&5
+-$as_echo_n "checking whether the compiler supports exceptions... " >&6; }
+-if ${ac_cv_cxx_exceptions+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports exceptions" >&5
++printf %s "checking whether the compiler supports exceptions... " >&6; }
++if test ${ac_cv_cxx_exceptions+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -6407,7 +7116,7 @@
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ try { throw  1; } catch (int i) { return i; }
+   ;
+@@ -6414,12 +7123,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   ac_cv_cxx_exceptions=yes
+-else
++else $as_nop
+   ac_cv_cxx_exceptions=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6428,19 +7138,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_exceptions" >&5
+-$as_echo "$ac_cv_cxx_exceptions" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_exceptions" >&5
++printf "%s\n" "$ac_cv_cxx_exceptions" >&6; }
+ if test "$ac_cv_cxx_exceptions" = yes; then
+ 
+-$as_echo "#define HAVE_EXCEPTIONS /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_EXCEPTIONS /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether exceptions can be caught by base class" >&5
+-$as_echo_n "checking whether exceptions can be caught by base class... " >&6; }
+-if ${omni_cv_cxx_catch_by_base+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether exceptions can be caught by base class" >&5
++printf %s "checking whether exceptions can be caught by base class... " >&6; }
++if test ${omni_cv_cxx_catch_by_base+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -6448,9 +7159,10 @@
+ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+ 
+- if test "$cross_compiling" = yes; then :
++ if test "$cross_compiling" = yes
++then :
+   omni_cv_cxx_catch_by_base=yes
+-else
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -6476,9 +7188,10 @@
+ }
+ 
+ _ACEOF
+-if ac_fn_cxx_try_run "$LINENO"; then :
++if ac_fn_cxx_try_run "$LINENO"
++then :
+   omni_cv_cxx_catch_by_base=yes
+-else
++else $as_nop
+   omni_cv_cxx_catch_by_base=no
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+@@ -6493,19 +7206,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_cxx_catch_by_base" >&5
+-$as_echo "$omni_cv_cxx_catch_by_base" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_cxx_catch_by_base" >&5
++printf "%s\n" "$omni_cv_cxx_catch_by_base" >&6; }
+ if test "$omni_cv_cxx_catch_by_base" = yes; then
+ 
+-$as_echo "#define HAVE_CATCH_BY_BASE /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_CATCH_BY_BASE /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether base constructors have to be fully-qualified" >&5
+-$as_echo_n "checking whether base constructors have to be fully-qualified... " >&6; }
+-if ${omni_cv_cxx_need_fq_base_ctor+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether base constructors have to be fully-qualified" >&5
++printf %s "checking whether base constructors have to be fully-qualified... " >&6; }
++if test ${omni_cv_cxx_need_fq_base_ctor+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6536,7 +7250,7 @@
+ };
+ 
+ int
+-main ()
++main (void)
+ {
+ C c; S s;
+   ;
+@@ -6543,12 +7257,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   omni_cv_cxx_need_fq_base_ctor=no
+-else
++else $as_nop
+   omni_cv_cxx_need_fq_base_ctor=yes
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6557,19 +7272,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_cxx_need_fq_base_ctor" >&5
+-$as_echo "$omni_cv_cxx_need_fq_base_ctor" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_cxx_need_fq_base_ctor" >&5
++printf "%s\n" "$omni_cv_cxx_need_fq_base_ctor" >&6; }
+ if test "$omni_cv_cxx_need_fq_base_ctor" = yes; then
+ 
+-$as_echo "#define OMNI_REQUIRES_FQ_BASE_CTOR /**/" >>confdefs.h
++printf "%s\n" "#define OMNI_REQUIRES_FQ_BASE_CTOR /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports covariant return types" >&5
+-$as_echo_n "checking whether the compiler supports covariant return types... " >&6; }
+-if ${omni_cv_cxx_covariant_returns+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports covariant return types" >&5
++printf %s "checking whether the compiler supports covariant return types... " >&6; }
++if test ${omni_cv_cxx_covariant_returns+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6591,7 +7307,7 @@
+ };
+ 
+ int
+-main ()
++main (void)
+ {
+ D d;
+   ;
+@@ -6598,12 +7314,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   omni_cv_cxx_covariant_returns=yes
+-else
++else $as_nop
+   omni_cv_cxx_covariant_returns=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6612,19 +7329,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_cxx_covariant_returns" >&5
+-$as_echo "$omni_cv_cxx_covariant_returns" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_cxx_covariant_returns" >&5
++printf "%s\n" "$omni_cv_cxx_covariant_returns" >&6; }
+ if test "$omni_cv_cxx_covariant_returns" = yes; then
+ 
+-$as_echo "#define OMNI_HAVE_COVARIANT_RETURNS /**/" >>confdefs.h
++printf "%s\n" "#define OMNI_HAVE_COVARIANT_RETURNS /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether long is the same type as int" >&5
+-$as_echo_n "checking whether long is the same type as int... " >&6; }
+-if ${omni_cv_cxx_long_is_int+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether long is the same type as int" >&5
++printf %s "checking whether long is the same type as int... " >&6; }
++if test ${omni_cv_cxx_long_is_int+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6638,7 +7356,7 @@
+ int f(long x){return 1;}
+ 
+ int
+-main ()
++main (void)
+ {
+ long l = 5; return f(l);
+   ;
+@@ -6645,12 +7363,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   omni_cv_cxx_long_is_int=no
+-else
++else $as_nop
+   omni_cv_cxx_long_is_int=yes
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -6659,11 +7378,11 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_cxx_long_is_int" >&5
+-$as_echo "$omni_cv_cxx_long_is_int" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_cxx_long_is_int" >&5
++printf "%s\n" "$omni_cv_cxx_long_is_int" >&6; }
+ if test "$omni_cv_cxx_long_is_int" = yes; then
+ 
+-$as_echo "#define OMNI_LONG_IS_INT /**/" >>confdefs.h
++printf "%s\n" "#define OMNI_LONG_IS_INT /**/" >>confdefs.h
+ 
+ fi
+ 
+@@ -6670,31 +7389,29 @@
+ 
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing getaddrinfo" >&5
+-$as_echo_n "checking for library containing getaddrinfo... " >&6; }
+-if ${ac_cv_search_getaddrinfo+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing getaddrinfo" >&5
++printf %s "checking for library containing getaddrinfo... " >&6; }
++if test ${ac_cv_search_getaddrinfo+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_func_search_save_LIBS=$LIBS
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+-/* Override any GCC internal prototype to avoid an error.
+-   Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
+-#ifdef __cplusplus
+-extern "C"
+-#endif
+-char getaddrinfo ();
++namespace conftest {
++  extern "C" int getaddrinfo ();
++}
+ int
+-main ()
++main (void)
+ {
+-return getaddrinfo ();
++return conftest::getaddrinfo ();
+   ;
+   return 0;
+ }
+ _ACEOF
+-for ac_lib in '' nsl socket; do
++for ac_lib in '' nsl socket
++do
+   if test -z "$ac_lib"; then
+     ac_res="none required"
+   else
+@@ -6701,27 +7418,31 @@
+     ac_res=-l$ac_lib
+     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+   fi
+-  if ac_fn_cxx_try_link "$LINENO"; then :
++  if ac_fn_cxx_try_link "$LINENO"
++then :
+   ac_cv_search_getaddrinfo=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext \
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
+     conftest$ac_exeext
+-  if ${ac_cv_search_getaddrinfo+:} false; then :
++  if test ${ac_cv_search_getaddrinfo+y}
++then :
+   break
+ fi
+ done
+-if ${ac_cv_search_getaddrinfo+:} false; then :
++if test ${ac_cv_search_getaddrinfo+y}
++then :
+ 
+-else
++else $as_nop
+   ac_cv_search_getaddrinfo=no
+ fi
+ rm conftest.$ac_ext
+ LIBS=$ac_func_search_save_LIBS
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_getaddrinfo" >&5
+-$as_echo "$ac_cv_search_getaddrinfo" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_getaddrinfo" >&5
++printf "%s\n" "$ac_cv_search_getaddrinfo" >&6; }
+ ac_res=$ac_cv_search_getaddrinfo
+-if test "$ac_res" != no; then :
++if test "$ac_res" != no
++then :
+   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+ 
+ fi
+@@ -6736,90 +7457,208 @@
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
+-for ac_func in getaddrinfo gethostname getopt getpid gettimeofday
+-do :
+-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+-if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+-_ACEOF
++ac_fn_c_check_func "$LINENO" "getaddrinfo" "ac_cv_func_getaddrinfo"
++if test "x$ac_cv_func_getaddrinfo" = xyes
++then :
++  printf "%s\n" "#define HAVE_GETADDRINFO 1" >>confdefs.h
+ 
+ fi
+-done
++ac_fn_c_check_func "$LINENO" "gethostname" "ac_cv_func_gethostname"
++if test "x$ac_cv_func_gethostname" = xyes
++then :
++  printf "%s\n" "#define HAVE_GETHOSTNAME 1" >>confdefs.h
+ 
+-for ac_func in getnameinfo inet_ntop
+-do :
+-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+-if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+-_ACEOF
++fi
++ac_fn_c_check_func "$LINENO" "getopt" "ac_cv_func_getopt"
++if test "x$ac_cv_func_getopt" = xyes
++then :
++  printf "%s\n" "#define HAVE_GETOPT 1" >>confdefs.h
+ 
+ fi
+-done
++ac_fn_c_check_func "$LINENO" "getpid" "ac_cv_func_getpid"
++if test "x$ac_cv_func_getpid" = xyes
++then :
++  printf "%s\n" "#define HAVE_GETPID 1" >>confdefs.h
+ 
+-for ac_func in isinf insinff isinfl localtime nanosleep poll rand_r sigaction
+-do :
+-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+-if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+-_ACEOF
++fi
++ac_fn_c_check_func "$LINENO" "gettimeofday" "ac_cv_func_gettimeofday"
++if test "x$ac_cv_func_gettimeofday" = xyes
++then :
++  printf "%s\n" "#define HAVE_GETTIMEOFDAY 1" >>confdefs.h
+ 
+ fi
+-done
+ 
+-for ac_func in sigvec snprintf strcasecmp strdup strerror strftime stricmp
+-do :
+-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+-if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+-_ACEOF
++ac_fn_c_check_func "$LINENO" "getnameinfo" "ac_cv_func_getnameinfo"
++if test "x$ac_cv_func_getnameinfo" = xyes
++then :
++  printf "%s\n" "#define HAVE_GETNAMEINFO 1" >>confdefs.h
+ 
+ fi
+-done
++ac_fn_c_check_func "$LINENO" "inet_ntop" "ac_cv_func_inet_ntop"
++if test "x$ac_cv_func_inet_ntop" = xyes
++then :
++  printf "%s\n" "#define HAVE_INET_NTOP 1" >>confdefs.h
+ 
+-for ac_func in strncasecmp strtoul strtoull strtouq uname vprintf vsnprintf
+-do :
+-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+-if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+-_ACEOF
++fi
+ 
++ac_fn_c_check_func "$LINENO" "isinf" "ac_cv_func_isinf"
++if test "x$ac_cv_func_isinf" = xyes
++then :
++  printf "%s\n" "#define HAVE_ISINF 1" >>confdefs.h
++
+ fi
+-done
++ac_fn_c_check_func "$LINENO" "insinff" "ac_cv_func_insinff"
++if test "x$ac_cv_func_insinff" = xyes
++then :
++  printf "%s\n" "#define HAVE_INSINFF 1" >>confdefs.h
+ 
++fi
++ac_fn_c_check_func "$LINENO" "isinfl" "ac_cv_func_isinfl"
++if test "x$ac_cv_func_isinfl" = xyes
++then :
++  printf "%s\n" "#define HAVE_ISINFL 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "localtime" "ac_cv_func_localtime"
++if test "x$ac_cv_func_localtime" = xyes
++then :
++  printf "%s\n" "#define HAVE_LOCALTIME 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "nanosleep" "ac_cv_func_nanosleep"
++if test "x$ac_cv_func_nanosleep" = xyes
++then :
++  printf "%s\n" "#define HAVE_NANOSLEEP 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "poll" "ac_cv_func_poll"
++if test "x$ac_cv_func_poll" = xyes
++then :
++  printf "%s\n" "#define HAVE_POLL 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "rand_r" "ac_cv_func_rand_r"
++if test "x$ac_cv_func_rand_r" = xyes
++then :
++  printf "%s\n" "#define HAVE_RAND_R 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "sigaction" "ac_cv_func_sigaction"
++if test "x$ac_cv_func_sigaction" = xyes
++then :
++  printf "%s\n" "#define HAVE_SIGACTION 1" >>confdefs.h
++
++fi
++
++ac_fn_c_check_func "$LINENO" "sigvec" "ac_cv_func_sigvec"
++if test "x$ac_cv_func_sigvec" = xyes
++then :
++  printf "%s\n" "#define HAVE_SIGVEC 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "snprintf" "ac_cv_func_snprintf"
++if test "x$ac_cv_func_snprintf" = xyes
++then :
++  printf "%s\n" "#define HAVE_SNPRINTF 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "strcasecmp" "ac_cv_func_strcasecmp"
++if test "x$ac_cv_func_strcasecmp" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRCASECMP 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "strdup" "ac_cv_func_strdup"
++if test "x$ac_cv_func_strdup" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRDUP 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "strerror" "ac_cv_func_strerror"
++if test "x$ac_cv_func_strerror" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRERROR 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "strftime" "ac_cv_func_strftime"
++if test "x$ac_cv_func_strftime" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRFTIME 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "stricmp" "ac_cv_func_stricmp"
++if test "x$ac_cv_func_stricmp" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRICMP 1" >>confdefs.h
++
++fi
++
++ac_fn_c_check_func "$LINENO" "strncasecmp" "ac_cv_func_strncasecmp"
++if test "x$ac_cv_func_strncasecmp" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRNCASECMP 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "strtoul" "ac_cv_func_strtoul"
++if test "x$ac_cv_func_strtoul" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRTOUL 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "strtoull" "ac_cv_func_strtoull"
++if test "x$ac_cv_func_strtoull" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRTOULL 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "strtouq" "ac_cv_func_strtouq"
++if test "x$ac_cv_func_strtouq" = xyes
++then :
++  printf "%s\n" "#define HAVE_STRTOUQ 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "uname" "ac_cv_func_uname"
++if test "x$ac_cv_func_uname" = xyes
++then :
++  printf "%s\n" "#define HAVE_UNAME 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "vprintf" "ac_cv_func_vprintf"
++if test "x$ac_cv_func_vprintf" = xyes
++then :
++  printf "%s\n" "#define HAVE_VPRINTF 1" >>confdefs.h
++
++fi
++ac_fn_c_check_func "$LINENO" "vsnprintf" "ac_cv_func_vsnprintf"
++if test "x$ac_cv_func_vsnprintf" = xyes
++then :
++  printf "%s\n" "#define HAVE_VSNPRINTF 1" >>confdefs.h
++
++fi
++
+ ac_fn_c_check_type "$LINENO" "size_t" "ac_cv_type_size_t" "$ac_includes_default"
+-if test "x$ac_cv_type_size_t" = xyes; then :
++if test "x$ac_cv_type_size_t" = xyes
++then :
+ 
+-else
++else $as_nop
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define size_t unsigned int
+-_ACEOF
++printf "%s\n" "#define size_t unsigned int" >>confdefs.h
+ 
+ fi
+ 
+-
+ # The Ultrix 4.2 mips builtin alloca declared by alloca.h only works
+ # for constant arguments.  Useless!
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for working alloca.h" >&5
+-$as_echo_n "checking for working alloca.h... " >&6; }
+-if ${ac_cv_working_alloca_h+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for working alloca.h" >&5
++printf %s "checking for working alloca.h... " >&6; }
++if test ${ac_cv_working_alloca_h+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <alloca.h>
+ int
+-main ()
++main (void)
+ {
+ char *p = (char *) alloca (2 * sizeof (int));
+ 			  if (p) return 0;
+@@ -6827,52 +7666,52 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_link "$LINENO"; then :
++if ac_fn_c_try_link "$LINENO"
++then :
+   ac_cv_working_alloca_h=yes
+-else
++else $as_nop
+   ac_cv_working_alloca_h=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext \
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_working_alloca_h" >&5
+-$as_echo "$ac_cv_working_alloca_h" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_working_alloca_h" >&5
++printf "%s\n" "$ac_cv_working_alloca_h" >&6; }
+ if test $ac_cv_working_alloca_h = yes; then
+ 
+-$as_echo "#define HAVE_ALLOCA_H 1" >>confdefs.h
++printf "%s\n" "#define HAVE_ALLOCA_H 1" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for alloca" >&5
+-$as_echo_n "checking for alloca... " >&6; }
+-if ${ac_cv_func_alloca_works+:} false; then :
+-  $as_echo_n "(cached) " >&6
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for alloca" >&5
++printf %s "checking for alloca... " >&6; }
++if test ${ac_cv_func_alloca_works+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test $ac_cv_working_alloca_h = yes; then
++  ac_cv_func_alloca_works=yes
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-#ifdef __GNUC__
+-# define alloca __builtin_alloca
+-#else
+-# ifdef _MSC_VER
++#include <stdlib.h>
++#include <stddef.h>
++#ifndef alloca
++# ifdef __GNUC__
++#  define alloca __builtin_alloca
++# elif defined _MSC_VER
+ #  include <malloc.h>
+ #  define alloca _alloca
+ # else
+-#  ifdef HAVE_ALLOCA_H
+-#   include <alloca.h>
+-#  else
+-#   ifdef _AIX
+- #pragma alloca
+-#   else
+-#    ifndef alloca /* predefined by HP cc +Olibcalls */
++#  ifdef  __cplusplus
++extern "C"
++#  endif
+ void *alloca (size_t);
+-#    endif
+-#   endif
+-#  endif
+ # endif
+ #endif
+ 
+ int
+-main ()
++main (void)
+ {
+ char *p = (char *) alloca (1);
+ 				    if (p) return 0;
+@@ -6880,20 +7719,22 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_link "$LINENO"; then :
++if ac_fn_c_try_link "$LINENO"
++then :
+   ac_cv_func_alloca_works=yes
+-else
++else $as_nop
+   ac_cv_func_alloca_works=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext \
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_alloca_works" >&5
+-$as_echo "$ac_cv_func_alloca_works" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_alloca_works" >&5
++printf "%s\n" "$ac_cv_func_alloca_works" >&6; }
++fi
+ 
+ if test $ac_cv_func_alloca_works = yes; then
+ 
+-$as_echo "#define HAVE_ALLOCA 1" >>confdefs.h
++printf "%s\n" "#define HAVE_ALLOCA 1" >>confdefs.h
+ 
+ else
+   # The SVR3 libPW and SVR4 libucb both contain incompatible functions
+@@ -6903,58 +7744,19 @@
+ 
+ ALLOCA=\${LIBOBJDIR}alloca.$ac_objext
+ 
+-$as_echo "#define C_ALLOCA 1" >>confdefs.h
++printf "%s\n" "#define C_ALLOCA 1" >>confdefs.h
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether \`alloca.c' needs Cray hooks" >&5
+-$as_echo_n "checking whether \`alloca.c' needs Cray hooks... " >&6; }
+-if ${ac_cv_os_cray+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#if defined CRAY && ! defined CRAY2
+-webecray
+-#else
+-wenotbecray
+-#endif
+-
+-_ACEOF
+-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+-  $EGREP "webecray" >/dev/null 2>&1; then :
+-  ac_cv_os_cray=yes
+-else
+-  ac_cv_os_cray=no
+-fi
+-rm -f conftest*
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_os_cray" >&5
+-$as_echo "$ac_cv_os_cray" >&6; }
+-if test $ac_cv_os_cray = yes; then
+-  for ac_func in _getb67 GETB67 getb67; do
+-    as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+-if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+-
+-cat >>confdefs.h <<_ACEOF
+-#define CRAY_STACKSEG_END $ac_func
+-_ACEOF
+-
+-    break
+-fi
+-
+-  done
+-fi
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking stack direction for C alloca" >&5
+-$as_echo_n "checking stack direction for C alloca... " >&6; }
+-if ${ac_cv_c_stack_direction+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test "$cross_compiling" = yes; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking stack direction for C alloca" >&5
++printf %s "checking stack direction for C alloca... " >&6; }
++if test ${ac_cv_c_stack_direction+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test "$cross_compiling" = yes
++then :
+   ac_cv_c_stack_direction=0
+-else
++else $as_nop
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ $ac_includes_default
+@@ -6975,9 +7777,10 @@
+   return find_stack_direction (0, argc + !argv + 20) < 0;
+ }
+ _ACEOF
+-if ac_fn_c_try_run "$LINENO"; then :
++if ac_fn_c_try_run "$LINENO"
++then :
+   ac_cv_c_stack_direction=1
+-else
++else $as_nop
+   ac_cv_c_stack_direction=-1
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+@@ -6985,11 +7788,9 @@
+ fi
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_stack_direction" >&5
+-$as_echo "$ac_cv_c_stack_direction" >&6; }
+-cat >>confdefs.h <<_ACEOF
+-#define STACK_DIRECTION $ac_cv_c_stack_direction
+-_ACEOF
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_stack_direction" >&5
++printf "%s\n" "$ac_cv_c_stack_direction" >&6; }
++printf "%s\n" "#define STACK_DIRECTION $ac_cv_c_stack_direction" >>confdefs.h
+ 
+ 
+ fi
+@@ -7001,11 +7802,12 @@
+ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for IsNANorINF" >&5
+-$as_echo_n "checking for IsNANorINF... " >&6; }
+-if ${omni_cv_have_isnanorinf+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for IsNANorINF" >&5
++printf %s "checking for IsNANorINF... " >&6; }
++if test ${omni_cv_have_isnanorinf+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -7019,7 +7821,7 @@
+ #include <nan.h>
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   double d = 1.23;
+@@ -7029,12 +7831,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   omni_cv_have_isnanorinf=yes
+-else
++else $as_nop
+   omni_cv_have_isnanorinf=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -7043,19 +7846,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_have_isnanorinf" >&5
+-$as_echo "$omni_cv_have_isnanorinf" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_have_isnanorinf" >&5
++printf "%s\n" "$omni_cv_have_isnanorinf" >&6; }
+ if test "$omni_cv_have_isnanorinf" = yes; then
+ 
+-$as_echo "#define HAVE_ISNANORINF /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_ISNANORINF /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether SIG_IGN is available" >&5
+-$as_echo_n "checking whether SIG_IGN is available... " >&6; }
+-if ${omni_cv_sig_ign_available+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether SIG_IGN is available" >&5
++printf %s "checking whether SIG_IGN is available... " >&6; }
++if test ${omni_cv_sig_ign_available+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -7075,7 +7879,7 @@
+ #endif
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+     struct sigaction act;
+@@ -7086,12 +7890,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   omni_cv_sig_ign_available=yes
+-else
++else $as_nop
+   omni_cv_sig_ign_available=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -7100,19 +7905,20 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_sig_ign_available" >&5
+-$as_echo "$omni_cv_sig_ign_available" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_sig_ign_available" >&5
++printf "%s\n" "$omni_cv_sig_ign_available" >&6; }
+ if test "$omni_cv_sig_ign_available" = yes; then
+ 
+-$as_echo "#define HAVE_SIG_IGN /**/" >>confdefs.h
++printf "%s\n" "#define HAVE_SIG_IGN /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether gettimeofday() takes a timezone argument" >&5
+-$as_echo_n "checking whether gettimeofday() takes a timezone argument... " >&6; }
+-if ${omni_cv_gettimeofday_timezone+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether gettimeofday() takes a timezone argument" >&5
++printf %s "checking whether gettimeofday() takes a timezone argument... " >&6; }
++if test ${omni_cv_gettimeofday_timezone+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -7129,7 +7935,7 @@
+ #endif
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   struct timeval v;
+@@ -7139,12 +7945,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   omni_cv_gettimeofday_timezone=yes
+-else
++else $as_nop
+   omni_cv_gettimeofday_timezone=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -7153,16 +7960,16 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_gettimeofday_timezone" >&5
+-$as_echo "$omni_cv_gettimeofday_timezone" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_gettimeofday_timezone" >&5
++printf "%s\n" "$omni_cv_gettimeofday_timezone" >&6; }
+ if test "$omni_cv_gettimeofday_timezone" = yes; then
+ 
+-$as_echo "#define GETTIMEOFDAY_TIMEZONE /**/" >>confdefs.h
++printf "%s\n" "#define GETTIMEOFDAY_TIMEZONE /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking third argument of getsockname" >&5
+-$as_echo_n "checking third argument of getsockname... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking third argument of getsockname" >&5
++printf %s "checking third argument of getsockname... " >&6; }
+  omni_cv_sockname_size_t=no
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -7180,7 +7987,7 @@
+ #include <unistd.h>
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   socklen_t l;
+@@ -7190,10 +7997,11 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   omni_cv_sockname_size_t=socklen_t
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  if test "$omni_cv_sockname_size_t" = no; then
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+@@ -7205,7 +8013,7 @@
+ #include <unistd.h>
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+   size_t l;
+@@ -7215,26 +8023,26 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
++if ac_fn_cxx_try_compile "$LINENO"
++then :
+   omni_cv_sockname_size_t=size_t
+-else
++else $as_nop
+   omni_cv_sockname_size_t=int
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  fi
+ 
+-cat >>confdefs.h <<_ACEOF
+-#define OMNI_SOCKNAME_SIZE_T $omni_cv_sockname_size_t
+-_ACEOF
++printf "%s\n" "#define OMNI_SOCKNAME_SIZE_T $omni_cv_sockname_size_t" >>confdefs.h
+ 
+- { $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_sockname_size_t" >&5
+-$as_echo "$omni_cv_sockname_size_t" >&6; }
++ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_sockname_size_t" >&5
++printf "%s\n" "$omni_cv_sockname_size_t" >&6; }
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether __sync_add_and_fetch and __sync_sub_and_fetch are present" >&5
+-$as_echo_n "checking whether __sync_add_and_fetch and __sync_sub_and_fetch are present... " >&6; }
+-if ${omni_cv_sync_add_and_fetch+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether __sync_add_and_fetch and __sync_sub_and_fetch are present" >&5
++printf %s "checking whether __sync_add_and_fetch and __sync_sub_and_fetch are present... " >&6; }
++if test ${omni_cv_sync_add_and_fetch+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -7245,7 +8053,7 @@
+ /* end confdefs.h.  */
+ 
+ int
+-main ()
++main (void)
+ {
+ 
+ int a = 1;
+@@ -7256,12 +8064,13 @@
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_link "$LINENO"; then :
++if ac_fn_cxx_try_link "$LINENO"
++then :
+   omni_cv_sync_add_and_fetch=yes
+-else
++else $as_nop
+   omni_cv_sync_add_and_fetch=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext \
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+  ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+@@ -7271,33 +8080,35 @@
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_sync_add_and_fetch" >&5
+-$as_echo "$omni_cv_sync_add_and_fetch" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_sync_add_and_fetch" >&5
++printf "%s\n" "$omni_cv_sync_add_and_fetch" >&6; }
+ if test "$omni_cv_sync_add_and_fetch" = yes; then
+ 
+-$as_echo "#define OMNI_HAVE_SYNC_ADD_AND_FETCH /**/" >>confdefs.h
++printf "%s\n" "#define OMNI_HAVE_SYNC_ADD_AND_FETCH /**/" >>confdefs.h
+ 
+ fi
+ 
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking omniORB config file location" >&5
+-$as_echo_n "checking omniORB config file location... " >&6; }
+-if ${omni_cv_omniorb_config+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking omniORB config file location" >&5
++printf %s "checking omniORB config file location... " >&6; }
++if test ${omni_cv_omniorb_config+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+ # Check whether --with-omniORB-config was given.
+-if test "${with_omniORB_config+set}" = set; then :
++if test ${with_omniORB_config+y}
++then :
+   withval=$with_omniORB_config; omni_cv_omniorb_config=$withval
+-else
++else $as_nop
+   omni_cv_omniorb_config="/etc/omniORB.cfg"
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_omniorb_config" >&5
+-$as_echo "$omni_cv_omniorb_config" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_omniorb_config" >&5
++printf "%s\n" "$omni_cv_omniorb_config" >&6; }
+ if test "$omni_cv_omniorb_config" = "no" || test "$omni_cv_omniorb_config" = "yes"; then
+   echo "*** invalid omniORB config file '$omni_cv_omniorb_config'; using '/etc/omniORB.cfg'"
+   omni_cv_omniorb_config="/etc/omniORB.cfg"
+@@ -7305,23 +8116,25 @@
+ OMNIORB_CONFIG=$omni_cv_omniorb_config
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking omniNames log directory" >&5
+-$as_echo_n "checking omniNames log directory... " >&6; }
+-if ${omni_cv_omninames_logdir+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking omniNames log directory" >&5
++printf %s "checking omniNames log directory... " >&6; }
++if test ${omni_cv_omninames_logdir+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+ 
+ # Check whether --with-omniNames-logdir was given.
+-if test "${with_omniNames_logdir+set}" = set; then :
++if test ${with_omniNames_logdir+y}
++then :
+   withval=$with_omniNames_logdir; omni_cv_omninames_logdir=$withval
+-else
++else $as_nop
+   omni_cv_omninames_logdir="/var/omninames"
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_omninames_logdir" >&5
+-$as_echo "$omni_cv_omninames_logdir" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_omninames_logdir" >&5
++printf "%s\n" "$omni_cv_omninames_logdir" >&6; }
+ if test "$omni_cv_omninames_logdir" = "no" || test "$omni_cv_omninames_logdir" = "yes"; then
+   echo "*** invalid omniNames log directory '$omni_cv_omninames_logdir'; using '/var/omninames'"
+   omni_cv_omninames_logdir="/var/omninames"
+@@ -7329,200 +8142,213 @@
+ OMNINAMES_LOGDIR=$omni_cv_omninames_logdir
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build static libraries" >&5
+-$as_echo_n "checking whether to build static libraries... " >&6; }
+-if ${omni_cv_enable_static+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to build static libraries" >&5
++printf %s "checking whether to build static libraries... " >&6; }
++if test ${omni_cv_enable_static+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   # Check whether --enable-static was given.
+-if test "${enable_static+set}" = set; then :
++if test ${enable_static+y}
++then :
+   enableval=$enable_static; omni_cv_enable_static=$enableval
+-else
++else $as_nop
+   omni_cv_enable_static=yes
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_static" >&5
+-$as_echo "$omni_cv_enable_static" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_static" >&5
++printf "%s\n" "$omni_cv_enable_static" >&6; }
+ ENABLE_STATIC=$omni_cv_enable_static
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to trace threads and locking" >&5
+-$as_echo_n "checking whether to trace threads and locking... " >&6; }
+-if ${omni_cv_enable_thread_tracing+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to trace threads and locking" >&5
++printf %s "checking whether to trace threads and locking... " >&6; }
++if test ${omni_cv_enable_thread_tracing+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   # Check whether --enable-thread-tracing was given.
+-if test "${enable_thread_tracing+set}" = set; then :
++if test ${enable_thread_tracing+y}
++then :
+   enableval=$enable_thread_tracing; omni_cv_enable_thread_tracing=$enableval
+-else
++else $as_nop
+   omni_cv_enable_thread_tracing=no
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_thread_tracing" >&5
+-$as_echo "$omni_cv_enable_thread_tracing" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_thread_tracing" >&5
++printf "%s\n" "$omni_cv_enable_thread_tracing" >&6; }
+ if test "$omni_cv_enable_thread_tracing" = "yes"; then
+ 
+-$as_echo "#define OMNIORB_ENABLE_LOCK_TRACES /**/" >>confdefs.h
++printf "%s\n" "#define OMNIORB_ENABLE_LOCK_TRACES /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to support IPv6" >&5
+-$as_echo_n "checking whether to support IPv6... " >&6; }
+-if ${omni_cv_enable_ipv6+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to support IPv6" >&5
++printf %s "checking whether to support IPv6... " >&6; }
++if test ${omni_cv_enable_ipv6+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   # Check whether --enable-ipv6 was given.
+-if test "${enable_ipv6+set}" = set; then :
++if test ${enable_ipv6+y}
++then :
+   enableval=$enable_ipv6; omni_cv_enable_ipv6=$enableval
+-else
++else $as_nop
+   omni_cv_enable_ipv6=yes
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_ipv6" >&5
+-$as_echo "$omni_cv_enable_ipv6" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_ipv6" >&5
++printf "%s\n" "$omni_cv_enable_ipv6" >&6; }
+ if test "$omni_cv_enable_ipv6" = "no"; then
+ 
+-$as_echo "#define OMNI_DISABLE_IPV6 /**/" >>confdefs.h
++printf "%s\n" "#define OMNI_DISABLE_IPV6 /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether alloca should be used in omnicpp" >&5
+-$as_echo_n "checking whether alloca should be used in omnicpp... " >&6; }
+-if ${omni_cv_enable_alloca+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether alloca should be used in omnicpp" >&5
++printf %s "checking whether alloca should be used in omnicpp... " >&6; }
++if test ${omni_cv_enable_alloca+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   # Check whether --enable-alloca was given.
+-if test "${enable_alloca+set}" = set; then :
++if test ${enable_alloca+y}
++then :
+   enableval=$enable_alloca; omni_cv_enable_alloca=$enableval
+-else
++else $as_nop
+   omni_cv_enable_alloca=yes
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_alloca" >&5
+-$as_echo "$omni_cv_enable_alloca" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_alloca" >&5
++printf "%s\n" "$omni_cv_enable_alloca" >&6; }
+ if test "$omni_cv_enable_alloca" = "no"; then
+ 
+-$as_echo "#define OMNIORB_DISABLE_ALLOCA /**/" >>confdefs.h
++printf "%s\n" "#define OMNIORB_DISABLE_ALLOCA /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to support long double" >&5
+-$as_echo_n "checking whether to support long double... " >&6; }
+-if ${omni_cv_enable_longdouble+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to support long double" >&5
++printf %s "checking whether to support long double... " >&6; }
++if test ${omni_cv_enable_longdouble+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   # Check whether --enable-longdouble was given.
+-if test "${enable_longdouble+set}" = set; then :
++if test ${enable_longdouble+y}
++then :
+   enableval=$enable_longdouble; omni_cv_enable_longdouble=$enableval
+-else
++else $as_nop
+   omni_cv_enable_longdouble=yes
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_longdouble" >&5
+-$as_echo "$omni_cv_enable_longdouble" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_longdouble" >&5
++printf "%s\n" "$omni_cv_enable_longdouble" >&6; }
+ if test "$omni_cv_enable_longdouble" = "no"; then
+ 
+-$as_echo "#define OMNIORB_DISABLE_LONGDOUBLE /**/" >>confdefs.h
++printf "%s\n" "#define OMNIORB_DISABLE_LONGDOUBLE /**/" >>confdefs.h
+ 
+ fi
+ ENABLE_LONGDOUBLE=$omni_cv_enable_longdouble
+ 
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to use atomic operations when possible" >&5
+-$as_echo_n "checking whether to use atomic operations when possible... " >&6; }
+-if ${omni_cv_enable_atomic+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to use atomic operations when possible" >&5
++printf %s "checking whether to use atomic operations when possible... " >&6; }
++if test ${omni_cv_enable_atomic+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   # Check whether --enable-atomic was given.
+-if test "${enable_atomic+set}" = set; then :
++if test ${enable_atomic+y}
++then :
+   enableval=$enable_atomic; omni_cv_enable_atomic=$enableval
+-else
++else $as_nop
+   omni_cv_enable_atomic=yes
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_atomic" >&5
+-$as_echo "$omni_cv_enable_atomic" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_atomic" >&5
++printf "%s\n" "$omni_cv_enable_atomic" >&6; }
+ if test "$omni_cv_enable_atomic" = "no"; then
+ 
+-$as_echo "#define OMNI_DISABLE_ATOMIC_OPS /**/" >>confdefs.h
++printf "%s\n" "#define OMNI_DISABLE_ATOMIC_OPS /**/" >>confdefs.h
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for compressBound in -lz" >&5
+-$as_echo_n "checking for compressBound in -lz... " >&6; }
+-if ${ac_cv_lib_z_compressBound+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for compressBound in -lz" >&5
++printf %s "checking for compressBound in -lz... " >&6; }
++if test ${ac_cv_lib_z_compressBound+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   ac_check_lib_save_LIBS=$LIBS
+ LIBS="-lz  $LIBS"
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+-/* Override any GCC internal prototype to avoid an error.
+-   Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
+-#ifdef __cplusplus
+-extern "C"
+-#endif
+-char compressBound ();
++namespace conftest {
++  extern "C" int compressBound ();
++}
+ int
+-main ()
++main (void)
+ {
+-return compressBound ();
++return conftest::compressBound ();
+   ;
+   return 0;
+ }
+ _ACEOF
+-if ac_fn_cxx_try_link "$LINENO"; then :
++if ac_fn_cxx_try_link "$LINENO"
++then :
+   ac_cv_lib_z_compressBound=yes
+-else
++else $as_nop
+   ac_cv_lib_z_compressBound=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext \
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_z_compressBound" >&5
+-$as_echo "$ac_cv_lib_z_compressBound" >&6; }
+-if test "x$ac_cv_lib_z_compressBound" = xyes; then :
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_z_compressBound" >&5
++printf "%s\n" "$ac_cv_lib_z_compressBound" >&6; }
++if test "x$ac_cv_lib_z_compressBound" = xyes
++then :
+   omni_cv_enable_ziop=yes
+-else
++else $as_nop
+   omni_cv_enable_ziop=no
+ fi
+ 
+ ENABLE_ZIOP=$omni_cv_enable_ziop
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to use CFNetwork" >&5
+-$as_echo_n "checking whether to use CFNetwork... " >&6; }
+-if ${omni_cv_enable_cfnetwork+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to use CFNetwork" >&5
++printf %s "checking whether to use CFNetwork... " >&6; }
++if test ${omni_cv_enable_cfnetwork+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
+   # Check whether --enable-cfnetwork was given.
+-if test "${enable_cfnetwork+set}" = set; then :
++if test ${enable_cfnetwork+y}
++then :
+   enableval=$enable_cfnetwork; omni_cv_enable_cfnetwork=$enableval
+-else
++else $as_nop
+   omni_cv_enable_cfnetwork=no
+ fi
+ 
+ 
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_cfnetwork" >&5
+-$as_echo "$omni_cv_enable_cfnetwork" >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $omni_cv_enable_cfnetwork" >&5
++printf "%s\n" "$omni_cv_enable_cfnetwork" >&6; }
+ if test "$omni_cv_enable_cfnetwork" = "yes"; then
+ 
+-$as_echo "#define OMNI_USE_CFNETWORK_CONNECT /**/" >>confdefs.h
++printf "%s\n" "#define OMNI_USE_CFNETWORK_CONNECT /**/" >>confdefs.h
+ 
+ fi
+ OMNI_USE_CFNETWORK_CONNECT=$omni_cv_enable_cfnetwork
+@@ -7618,6 +8444,7 @@
+   alpha*)   proc_name="AlphaProcessor";   proc_def="__alpha__";;
+   m68k-*)   proc_name="m68kProcessor";    proc_def="__m68k__";;
+   mips*)    proc_name="IndigoProcessor";  proc_def="__mips__";;
++  arm64-*)  proc_name="Arm64Processor";   proc_def="__arm64__";;
+   arm-*)    proc_name="ArmProcessor";     proc_def="__arm__";;
+   s390-*)   proc_name="s390Processor";    proc_def="__s390__";;
+   ia64-*)   proc_name="ia64Processor";    proc_def="__ia64__";;
+@@ -7681,8 +8508,8 @@
+     case $ac_val in #(
+     *${as_nl}*)
+       case $ac_var in #(
+-      *_cv_*) { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
+-$as_echo "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
++      *_cv_*) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
++printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
+       esac
+       case $ac_var in #(
+       _ | IFS | as_nl) ;; #(
+@@ -7712,7 +8539,7 @@
+      /^ac_cv_env_/b end
+      t clear
+      :clear
+-     s/^\([^=]*\)=\(.*[{}].*\)$/test "${\1+set}" = set || &/
++     s/^\([^=]*\)=\(.*[{}].*\)$/test ${\1+y} || &/
+      t end
+      s/^\([^=]*\)=\(.*\)$/\1=${\1=\2}/
+      :end' >>confcache
+@@ -7719,8 +8546,8 @@
+ if diff "$cache_file" confcache >/dev/null 2>&1; then :; else
+   if test -w "$cache_file"; then
+     if test "x$cache_file" != "x/dev/null"; then
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: updating cache $cache_file" >&5
+-$as_echo "$as_me: updating cache $cache_file" >&6;}
++      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: updating cache $cache_file" >&5
++printf "%s\n" "$as_me: updating cache $cache_file" >&6;}
+       if test ! -f "$cache_file" || test -h "$cache_file"; then
+ 	cat confcache >"$cache_file"
+       else
+@@ -7734,8 +8561,8 @@
+       fi
+     fi
+   else
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: not updating unwritable cache $cache_file" >&5
+-$as_echo "$as_me: not updating unwritable cache $cache_file" >&6;}
++    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: not updating unwritable cache $cache_file" >&5
++printf "%s\n" "$as_me: not updating unwritable cache $cache_file" >&6;}
+   fi
+ fi
+ rm -f confcache
+@@ -7752,7 +8579,7 @@
+ for ac_i in : $LIBOBJS; do test "x$ac_i" = x: && continue
+   # 1. Remove the extension, and $U if already installed.
+   ac_script='s/\$U\././;s/\.o$//;s/\.obj$//'
+-  ac_i=`$as_echo "$ac_i" | sed "$ac_script"`
++  ac_i=`printf "%s\n" "$ac_i" | sed "$ac_script"`
+   # 2. Prepend LIBOBJDIR.  When used with automake>=1.10 LIBOBJDIR
+   #    will be set to the directory where LIBOBJS objects are built.
+   as_fn_append ac_libobjs " \${LIBOBJDIR}$ac_i\$U.$ac_objext"
+@@ -7769,8 +8596,8 @@
+ ac_write_fail=0
+ ac_clean_files_save=$ac_clean_files
+ ac_clean_files="$ac_clean_files $CONFIG_STATUS"
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: creating $CONFIG_STATUS" >&5
+-$as_echo "$as_me: creating $CONFIG_STATUS" >&6;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: creating $CONFIG_STATUS" >&5
++printf "%s\n" "$as_me: creating $CONFIG_STATUS" >&6;}
+ as_write_fail=0
+ cat >$CONFIG_STATUS <<_ASEOF || as_write_fail=1
+ #! $SHELL
+@@ -7793,7 +8620,9 @@
+ 
+ # Be more Bourne compatible
+ DUALCASE=1; export DUALCASE # for MKS sh
+-if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :
++as_nop=:
++if test ${ZSH_VERSION+y} && (emulate sh) >/dev/null 2>&1
++then :
+   emulate sh
+   NULLCMD=:
+   # Pre-4.2 versions of Zsh do word splitting on ${1+"$@"}, which
+@@ -7800,7 +8629,7 @@
+   # is contrary to our usage.  Disable this feature.
+   alias -g '${1+"$@"}'='"$@"'
+   setopt NO_GLOB_SUBST
+-else
++else $as_nop
+   case `(set -o) 2>/dev/null` in #(
+   *posix*) :
+     set -o posix ;; #(
+@@ -7810,46 +8639,46 @@
+ fi
+ 
+ 
++
++# Reset variables that may have inherited troublesome values from
++# the environment.
++
++# IFS needs to be set, to space, tab, and newline, in precisely that order.
++# (If _AS_PATH_WALK were called with IFS unset, it would have the
++# side effect of setting IFS to empty, thus disabling word splitting.)
++# Quoting is to prevent editors from complaining about space-tab.
+ as_nl='
+ '
+ export as_nl
+-# Printing a long string crashes Solaris 7 /usr/bin/printf.
+-as_echo='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+-as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo
+-as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo$as_echo
+-# Prefer a ksh shell builtin over an external printf program on Solaris,
+-# but without wasting forks for bash or zsh.
+-if test -z "$BASH_VERSION$ZSH_VERSION" \
+-    && (test "X`print -r -- $as_echo`" = "X$as_echo") 2>/dev/null; then
+-  as_echo='print -r --'
+-  as_echo_n='print -rn --'
+-elif (test "X`printf %s $as_echo`" = "X$as_echo") 2>/dev/null; then
+-  as_echo='printf %s\n'
+-  as_echo_n='printf %s'
+-else
+-  if test "X`(/usr/ucb/echo -n -n $as_echo) 2>/dev/null`" = "X-n $as_echo"; then
+-    as_echo_body='eval /usr/ucb/echo -n "$1$as_nl"'
+-    as_echo_n='/usr/ucb/echo -n'
+-  else
+-    as_echo_body='eval expr "X$1" : "X\\(.*\\)"'
+-    as_echo_n_body='eval
+-      arg=$1;
+-      case $arg in #(
+-      *"$as_nl"*)
+-	expr "X$arg" : "X\\(.*\\)$as_nl";
+-	arg=`expr "X$arg" : ".*$as_nl\\(.*\\)"`;;
+-      esac;
+-      expr "X$arg" : "X\\(.*\\)" | tr -d "$as_nl"
+-    '
+-    export as_echo_n_body
+-    as_echo_n='sh -c $as_echo_n_body as_echo'
+-  fi
+-  export as_echo_body
+-  as_echo='sh -c $as_echo_body as_echo'
+-fi
++IFS=" ""	$as_nl"
+ 
++PS1='$ '
++PS2='> '
++PS4='+ '
++
++# Ensure predictable behavior from utilities with locale-dependent output.
++LC_ALL=C
++export LC_ALL
++LANGUAGE=C
++export LANGUAGE
++
++# We cannot yet rely on "unset" to work, but we need these variables
++# to be unset--not just set to an empty or harmless value--now, to
++# avoid bugs in old shells (e.g. pre-3.0 UWIN ksh).  This construct
++# also avoids known problems related to "unset" and subshell syntax
++# in other old shells (e.g. bash 2.01 and pdksh 5.2.14).
++for as_var in BASH_ENV ENV MAIL MAILPATH CDPATH
++do eval test \${$as_var+y} \
++  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
++done
++
++# Ensure that fds 0, 1, and 2 are open.
++if (exec 3>&0) 2>/dev/null; then :; else exec 0</dev/null; fi
++if (exec 3>&1) 2>/dev/null; then :; else exec 1>/dev/null; fi
++if (exec 3>&2)            ; then :; else exec 2>/dev/null; fi
++
+ # The user is always right.
+-if test "${PATH_SEPARATOR+set}" != set; then
++if ${PATH_SEPARATOR+false} :; then
+   PATH_SEPARATOR=:
+   (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {
+     (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 ||
+@@ -7858,13 +8687,6 @@
+ fi
+ 
+ 
+-# IFS
+-# We need space, tab and new line, in precisely that order.  Quoting is
+-# there to prevent editors from complaining about space-tab.
+-# (If _AS_PATH_WALK were called with IFS unset, it would disable word
+-# splitting by setting IFS to empty value.)
+-IFS=" ""	$as_nl"
+-
+ # Find who we are.  Look in the path if we contain no directory separator.
+ as_myself=
+ case $0 in #((
+@@ -7873,8 +8695,12 @@
+ for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    test -r "$as_dir/$0" && as_myself=$as_dir/$0 && break
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    test -r "$as_dir$0" && as_myself=$as_dir$0 && break
+   done
+ IFS=$as_save_IFS
+ 
+@@ -7886,32 +8712,12 @@
+   as_myself=$0
+ fi
+ if test ! -f "$as_myself"; then
+-  $as_echo "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
++  printf "%s\n" "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
+   exit 1
+ fi
+ 
+-# Unset variables that we do not need and which cause bugs (e.g. in
+-# pre-3.0 UWIN ksh).  But do not cause bugs in bash 2.01; the "|| exit 1"
+-# suppresses any "Segmentation fault" message there.  '((' could
+-# trigger a bug in pdksh 5.2.14.
+-for as_var in BASH_ENV ENV MAIL MAILPATH
+-do eval test x\${$as_var+set} = xset \
+-  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
+-done
+-PS1='$ '
+-PS2='> '
+-PS4='+ '
+ 
+-# NLS nuisances.
+-LC_ALL=C
+-export LC_ALL
+-LANGUAGE=C
+-export LANGUAGE
+ 
+-# CDPATH.
+-(unset CDPATH) >/dev/null 2>&1 && unset CDPATH
+-
+-
+ # as_fn_error STATUS ERROR [LINENO LOG_FD]
+ # ----------------------------------------
+ # Output "`basename $0`: error: ERROR" to stderr. If LINENO and LOG_FD are
+@@ -7922,13 +8728,14 @@
+   as_status=$1; test $as_status -eq 0 && as_status=1
+   if test "$4"; then
+     as_lineno=${as_lineno-"$3"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-    $as_echo "$as_me:${as_lineno-$LINENO}: error: $2" >&$4
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: $2" >&$4
+   fi
+-  $as_echo "$as_me: error: $2" >&2
++  printf "%s\n" "$as_me: error: $2" >&2
+   as_fn_exit $as_status
+ } # as_fn_error
+ 
+ 
++
+ # as_fn_set_status STATUS
+ # -----------------------
+ # Set $? to STATUS, without forking.
+@@ -7955,6 +8762,7 @@
+   { eval $1=; unset $1;}
+ }
+ as_unset=as_fn_unset
++
+ # as_fn_append VAR VALUE
+ # ----------------------
+ # Append the text in VALUE to the end of the definition contained in VAR. Take
+@@ -7961,12 +8769,13 @@
+ # advantage of any shell optimizations that allow amortized linear growth over
+ # repeated appends, instead of the typical quadratic growth present in naive
+ # implementations.
+-if (eval "as_var=1; as_var+=2; test x\$as_var = x12") 2>/dev/null; then :
++if (eval "as_var=1; as_var+=2; test x\$as_var = x12") 2>/dev/null
++then :
+   eval 'as_fn_append ()
+   {
+     eval $1+=\$2
+   }'
+-else
++else $as_nop
+   as_fn_append ()
+   {
+     eval $1=\$$1\$2
+@@ -7978,12 +8787,13 @@
+ # Perform arithmetic evaluation on the ARGs, and store the result in the
+ # global $as_val. Take advantage of shells that can avoid forks. The arguments
+ # must be portable across $(()) and expr.
+-if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null; then :
++if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null
++then :
+   eval 'as_fn_arith ()
+   {
+     as_val=$(( $* ))
+   }'
+-else
++else $as_nop
+   as_fn_arith ()
+   {
+     as_val=`expr "$@" || test $? -eq 1`
+@@ -8014,7 +8824,7 @@
+ $as_expr X/"$0" : '.*/\([^/][^/]*\)/*$' \| \
+ 	 X"$0" : 'X\(//\)$' \| \
+ 	 X"$0" : 'X\(/\)' \| . 2>/dev/null ||
+-$as_echo X/"$0" |
++printf "%s\n" X/"$0" |
+     sed '/^.*\/\([^/][^/]*\)\/*$/{
+ 	    s//\1/
+ 	    q
+@@ -8036,6 +8846,10 @@
+ as_cr_digits='0123456789'
+ as_cr_alnum=$as_cr_Letters$as_cr_digits
+ 
++
++# Determine whether it's possible to make 'echo' print without a newline.
++# These variables are no longer used directly by Autoconf, but are AC_SUBSTed
++# for compatibility with existing Makefiles.
+ ECHO_C= ECHO_N= ECHO_T=
+ case `echo -n x` in #(((((
+ -n*)
+@@ -8049,6 +8863,12 @@
+   ECHO_N='-n';;
+ esac
+ 
++# For backward compatibility with old third-party macros, we provide
++# the shell variables $as_echo and $as_echo_n.  New code should use
++# AS_ECHO(["message"]) and AS_ECHO_N(["message"]), respectively.
++as_echo='printf %s\n'
++as_echo_n='printf %s'
++
+ rm -f conf$$ conf$$.exe conf$$.file
+ if test -d conf$$.dir; then
+   rm -f conf$$.dir/conf$$.file
+@@ -8090,7 +8910,7 @@
+     as_dirs=
+     while :; do
+       case $as_dir in #(
+-      *\'*) as_qdir=`$as_echo "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
++      *\'*) as_qdir=`printf "%s\n" "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
+       *) as_qdir=$as_dir;;
+       esac
+       as_dirs="'$as_qdir' $as_dirs"
+@@ -8099,7 +8919,7 @@
+ 	 X"$as_dir" : 'X\(//\)[^/]' \| \
+ 	 X"$as_dir" : 'X\(//\)$' \| \
+ 	 X"$as_dir" : 'X\(/\)' \| . 2>/dev/null ||
+-$as_echo X"$as_dir" |
++printf "%s\n" X"$as_dir" |
+     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
+ 	    s//\1/
+ 	    q
+@@ -8162,7 +8982,7 @@
+ # values after options handling.
+ ac_log="
+ This file was extended by omniORB $as_me 4.2.5, which was
+-generated by GNU Autoconf 2.69.  Invocation command line was
++generated by GNU Autoconf 2.71.  Invocation command line was
+ 
+   CONFIG_FILES    = $CONFIG_FILES
+   CONFIG_HEADERS  = $CONFIG_HEADERS
+@@ -8220,14 +9040,16 @@
+ Report bugs to <bugs@omniorb-support.com>."
+ 
+ _ACEOF
++ac_cs_config=`printf "%s\n" "$ac_configure_args" | sed "$ac_safe_unquote"`
++ac_cs_config_escaped=`printf "%s\n" "$ac_cs_config" | sed "s/^ //; s/'/'\\\\\\\\''/g"`
+ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
+-ac_cs_config="`$as_echo "$ac_configure_args" | sed 's/^ //; s/[\\""\`\$]/\\\\&/g'`"
++ac_cs_config='$ac_cs_config_escaped'
+ ac_cs_version="\\
+ omniORB config.status 4.2.5
+-configured by $0, generated by GNU Autoconf 2.69,
++configured by $0, generated by GNU Autoconf 2.71,
+   with options \\"\$ac_cs_config\\"
+ 
+-Copyright (C) 2012 Free Software Foundation, Inc.
++Copyright (C) 2021 Free Software Foundation, Inc.
+ This config.status script is free software; the Free Software Foundation
+ gives unlimited permission to copy, distribute and modify it."
+ 
+@@ -8265,15 +9087,15 @@
+   -recheck | --recheck | --rechec | --reche | --rech | --rec | --re | --r)
+     ac_cs_recheck=: ;;
+   --version | --versio | --versi | --vers | --ver | --ve | --v | -V )
+-    $as_echo "$ac_cs_version"; exit ;;
++    printf "%s\n" "$ac_cs_version"; exit ;;
+   --config | --confi | --conf | --con | --co | --c )
+-    $as_echo "$ac_cs_config"; exit ;;
++    printf "%s\n" "$ac_cs_config"; exit ;;
+   --debug | --debu | --deb | --de | --d | -d )
+     debug=: ;;
+   --file | --fil | --fi | --f )
+     $ac_shift
+     case $ac_optarg in
+-    *\'*) ac_optarg=`$as_echo "$ac_optarg" | sed "s/'/'\\\\\\\\''/g"` ;;
++    *\'*) ac_optarg=`printf "%s\n" "$ac_optarg" | sed "s/'/'\\\\\\\\''/g"` ;;
+     '') as_fn_error $? "missing file argument" ;;
+     esac
+     as_fn_append CONFIG_FILES " '$ac_optarg'"
+@@ -8281,7 +9103,7 @@
+   --header | --heade | --head | --hea )
+     $ac_shift
+     case $ac_optarg in
+-    *\'*) ac_optarg=`$as_echo "$ac_optarg" | sed "s/'/'\\\\\\\\''/g"` ;;
++    *\'*) ac_optarg=`printf "%s\n" "$ac_optarg" | sed "s/'/'\\\\\\\\''/g"` ;;
+     esac
+     as_fn_append CONFIG_HEADERS " '$ac_optarg'"
+     ac_need_defaults=false;;
+@@ -8290,7 +9112,7 @@
+     as_fn_error $? "ambiguous option: \`$1'
+ Try \`$0 --help' for more information.";;
+   --help | --hel | -h )
+-    $as_echo "$ac_cs_usage"; exit ;;
++    printf "%s\n" "$ac_cs_usage"; exit ;;
+   -q | -quiet | --quiet | --quie | --qui | --qu | --q \
+   | -silent | --silent | --silen | --sile | --sil | --si | --s)
+     ac_cs_silent=: ;;
+@@ -8318,7 +9140,7 @@
+ if \$ac_cs_recheck; then
+   set X $SHELL '$0' $ac_configure_args \$ac_configure_extra_args --no-create --no-recursion
+   shift
+-  \$as_echo "running CONFIG_SHELL=$SHELL \$*" >&6
++  \printf "%s\n" "running CONFIG_SHELL=$SHELL \$*" >&6
+   CONFIG_SHELL='$SHELL'
+   export CONFIG_SHELL
+   exec "\$@"
+@@ -8332,7 +9154,7 @@
+   sed 'h;s/./-/g;s/^.../## /;s/...$/ ##/;p;x;p;x' <<_ASBOX
+ ## Running $as_me. ##
+ _ASBOX
+-  $as_echo "$ac_log"
++  printf "%s\n" "$ac_log"
+ } >&5
+ 
+ _ACEOF
+@@ -8451,8 +9273,8 @@
+ # We use the long form for the default assignment because of an extremely
+ # bizarre bug on SunOS 4.1.3.
+ if $ac_need_defaults; then
+-  test "${CONFIG_FILES+set}" = set || CONFIG_FILES=$config_files
+-  test "${CONFIG_HEADERS+set}" = set || CONFIG_HEADERS=$config_headers
++  test ${CONFIG_FILES+y} || CONFIG_FILES=$config_files
++  test ${CONFIG_HEADERS+y} || CONFIG_HEADERS=$config_headers
+ fi
+ 
+ # Have a temporary directory for convenience.  Make it in the build tree
+@@ -8788,7 +9610,7 @@
+ 	   esac ||
+ 	   as_fn_error 1 "cannot find input file: \`$ac_f'" "$LINENO" 5;;
+       esac
+-      case $ac_f in *\'*) ac_f=`$as_echo "$ac_f" | sed "s/'/'\\\\\\\\''/g"`;; esac
++      case $ac_f in *\'*) ac_f=`printf "%s\n" "$ac_f" | sed "s/'/'\\\\\\\\''/g"`;; esac
+       as_fn_append ac_file_inputs " '$ac_f'"
+     done
+ 
+@@ -8796,17 +9618,17 @@
+     # use $as_me), people would be surprised to read:
+     #    /* config.h.  Generated by config.status.  */
+     configure_input='Generated from '`
+-	  $as_echo "$*" | sed 's|^[^:]*/||;s|:[^:]*/|, |g'
++	  printf "%s\n" "$*" | sed 's|^[^:]*/||;s|:[^:]*/|, |g'
+ 	`' by configure.'
+     if test x"$ac_file" != x-; then
+       configure_input="$ac_file.  $configure_input"
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: creating $ac_file" >&5
+-$as_echo "$as_me: creating $ac_file" >&6;}
++      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: creating $ac_file" >&5
++printf "%s\n" "$as_me: creating $ac_file" >&6;}
+     fi
+     # Neutralize special characters interpreted by sed in replacement strings.
+     case $configure_input in #(
+     *\&* | *\|* | *\\* )
+-       ac_sed_conf_input=`$as_echo "$configure_input" |
++       ac_sed_conf_input=`printf "%s\n" "$configure_input" |
+        sed 's/[\\\\&|]/\\\\&/g'`;; #(
+     *) ac_sed_conf_input=$configure_input;;
+     esac
+@@ -8823,7 +9645,7 @@
+ 	 X"$ac_file" : 'X\(//\)[^/]' \| \
+ 	 X"$ac_file" : 'X\(//\)$' \| \
+ 	 X"$ac_file" : 'X\(/\)' \| . 2>/dev/null ||
+-$as_echo X"$ac_file" |
++printf "%s\n" X"$ac_file" |
+     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
+ 	    s//\1/
+ 	    q
+@@ -8847,9 +9669,9 @@
+ case "$ac_dir" in
+ .) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
+ *)
+-  ac_dir_suffix=/`$as_echo "$ac_dir" | sed 's|^\.[\\/]||'`
++  ac_dir_suffix=/`printf "%s\n" "$ac_dir" | sed 's|^\.[\\/]||'`
+   # A ".." for each directory in $ac_dir_suffix.
+-  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
++  ac_top_builddir_sub=`printf "%s\n" "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+   case $ac_top_builddir_sub in
+   "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
+   *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
+@@ -8906,8 +9728,8 @@
+ case `eval "sed -n \"\$ac_sed_dataroot\" $ac_file_inputs"` in
+ *datarootdir*) ac_datarootdir_seen=yes;;
+ *@datadir@*|*@docdir@*|*@infodir@*|*@localedir@*|*@mandir@*)
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file_inputs seems to ignore the --datarootdir setting" >&5
+-$as_echo "$as_me: WARNING: $ac_file_inputs seems to ignore the --datarootdir setting" >&2;}
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file_inputs seems to ignore the --datarootdir setting" >&5
++printf "%s\n" "$as_me: WARNING: $ac_file_inputs seems to ignore the --datarootdir setting" >&2;}
+ _ACEOF
+ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
+   ac_datarootdir_hack='
+@@ -8950,9 +9772,9 @@
+   { ac_out=`sed -n '/\${datarootdir}/p' "$ac_tmp/out"`; test -n "$ac_out"; } &&
+   { ac_out=`sed -n '/^[	 ]*datarootdir[	 ]*:*=/p' \
+       "$ac_tmp/out"`; test -z "$ac_out"; } &&
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file contains a reference to the variable \`datarootdir'
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file contains a reference to the variable \`datarootdir'
+ which seems to be undefined.  Please make sure it is defined" >&5
+-$as_echo "$as_me: WARNING: $ac_file contains a reference to the variable \`datarootdir'
++printf "%s\n" "$as_me: WARNING: $ac_file contains a reference to the variable \`datarootdir'
+ which seems to be undefined.  Please make sure it is defined" >&2;}
+ 
+   rm -f "$ac_tmp/stdin"
+@@ -8968,13 +9790,13 @@
+   #
+   if test x"$ac_file" != x-; then
+     {
+-      $as_echo "/* $configure_input  */" \
++      printf "%s\n" "/* $configure_input  */" >&1 \
+       && eval '$AWK -f "$ac_tmp/defines.awk"' "$ac_file_inputs"
+     } >"$ac_tmp/config.h" \
+       || as_fn_error $? "could not create $ac_file" "$LINENO" 5
+     if diff "$ac_file" "$ac_tmp/config.h" >/dev/null 2>&1; then
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: $ac_file is unchanged" >&5
+-$as_echo "$as_me: $ac_file is unchanged" >&6;}
++      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: $ac_file is unchanged" >&5
++printf "%s\n" "$as_me: $ac_file is unchanged" >&6;}
+     else
+       rm -f "$ac_file"
+       mv "$ac_tmp/config.h" "$ac_file" \
+@@ -8981,7 +9803,7 @@
+ 	|| as_fn_error $? "could not create $ac_file" "$LINENO" 5
+     fi
+   else
+-    $as_echo "/* $configure_input  */" \
++    printf "%s\n" "/* $configure_input  */" >&1 \
+       && eval '$AWK -f "$ac_tmp/defines.awk"' "$ac_file_inputs" \
+       || as_fn_error $? "could not create -" "$LINENO" 5
+   fi
+@@ -9022,7 +9844,8 @@
+   $ac_cs_success || as_fn_exit 1
+ fi
+ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
+-$as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
++printf "%s\n" "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
+ fi
+ 
++
+Index: omniORB/configure.ac
+===================================================================
+--- omniORB/configure.ac	(revision 6647)
++++ omniORB/configure.ac	(revision 6648)
+@@ -74,7 +74,6 @@
+ AC_CHECK_HEADERS(errno.h fcntl.h netdb.h signal.h stdlib.h string.h strings.h)
+ AC_CHECK_HEADERS(unistd.h nan.h sys/if.h sys/ioctl.h sys/param.h sys/time.h)
+ AC_CHECK_HEADERS(sys/poll.h ifaddrs.h)
+-AC_HEADER_TIME
+ 
+ 
+ dnl ** Integer representation
+@@ -247,6 +246,7 @@
+   alpha*)   proc_name="AlphaProcessor";   proc_def="__alpha__";;
+   m68k-*)   proc_name="m68kProcessor";    proc_def="__m68k__";;
+   mips*)    proc_name="IndigoProcessor";  proc_def="__mips__";;
++  arm64-*)  proc_name="Arm64Processor";   proc_def="__arm64__";;
+   arm-*)    proc_name="ArmProcessor";     proc_def="__arm__";;
+   s390-*)   proc_name="s390Processor";    proc_def="__s390__";;
+   ia64-*)   proc_name="ia64Processor";    proc_def="__ia64__";;
+@@ -349,7 +349,7 @@
+ AC_CONFIG_FILES(contrib/GNUmakefile
+                 contrib/pkgconfig/GNUmakefile)
+ 
+-AC_OUTPUT([
++AC_CONFIG_FILES([
+ contrib/pkgconfig/omnithread3.pc
+ contrib/pkgconfig/omniORB4.pc
+ contrib/pkgconfig/omniDynamic4.pc
+@@ -359,3 +359,4 @@
+ contrib/pkgconfig/omniZIOP4.pc
+ contrib/pkgconfig/omniZIOPDynamic4.pc
+ ])
++AC_OUTPUT
+Index: omniORB/include/omniORB4/CORBA_sysdep.h
+===================================================================
+--- omniORB/include/omniORB4/CORBA_sysdep.h	(revision 6647)
++++ omniORB/include/omniORB4/CORBA_sysdep.h	(revision 6648)
+@@ -89,7 +89,7 @@
+ // __VFP_FP__ means that the floating point format in use is that of the ARM 
+ // VFP unit, which is native-endian IEEE-754.
+ #if defined(__arm__)
+-#  if defined(__armv5teb__) || defined(__VFP_FP__) || defined(__aarch64__)
++#  if defined(__armv5teb__) || defined(__VFP_FP__) || defined(__aarch64__) || defined(__arm64__)
+ #    define NO_OMNI_MIXED_ENDIAN_DOUBLE
+ #  else
+ #    define OMNI_MIXED_ENDIAN_DOUBLE
+Index: omniORB/include/omniORB4/acconfig.h.in
+===================================================================
+--- omniORB/include/omniORB4/acconfig.h.in	(revision 6647)
++++ omniORB/include/omniORB4/acconfig.h.in	(revision 6648)
+@@ -3,22 +3,16 @@
+ /* Define if building universal (internal helper macro) */
+ #undef AC_APPLE_UNIVERSAL_BUILD
+ 
+-/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
+-   systems. This function is required for `alloca.c' support on those systems.
+-   */
+-#undef CRAY_STACKSEG_END
+-
+-/* Define to 1 if using `alloca.c'. */
++/* Define to 1 if using 'alloca.c'. */
+ #undef C_ALLOCA
+ 
+ /* define if gettimeofday() takes a timezone argument */
+ #undef GETTIMEOFDAY_TIMEZONE
+ 
+-/* Define to 1 if you have `alloca', as a function or macro. */
++/* Define to 1 if you have 'alloca', as a function or macro. */
+ #undef HAVE_ALLOCA
+ 
+-/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+-   */
++/* Define to 1 if <alloca.h> works. */
+ #undef HAVE_ALLOCA_H
+ 
+ /* define if bool is a built-in type */
+@@ -87,9 +81,6 @@
+ /* define if the compiler supports member constants */
+ #undef HAVE_MEMBER_CONSTANTS
+ 
+-/* Define to 1 if you have the <memory.h> header file. */
+-#undef HAVE_MEMORY_H
+-
+ /* define if the compiler implements namespaces */
+ #undef HAVE_NAMESPACES
+ 
+@@ -132,6 +123,9 @@
+ /* Define to 1 if you have the <stdint.h> header file. */
+ #undef HAVE_STDINT_H
+ 
++/* Define to 1 if you have the <stdio.h> header file. */
++#undef HAVE_STDIO_H
++
+ /* Define to 1 if you have the <stdlib.h> header file. */
+ #undef HAVE_STDLIB_H
+ 
+@@ -311,12 +305,11 @@
+ 	STACK_DIRECTION = 0 => direction of growth unknown */
+ #undef STACK_DIRECTION
+ 
+-/* Define to 1 if you have the ANSI C header files. */
++/* Define to 1 if all of the C90 standard headers exist (not just the ones
++   required in a freestanding environment). This macro is provided for
++   backward compatibility; new code need not use it. */
+ #undef STDC_HEADERS
+ 
+-/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+-#undef TIME_WITH_SYS_TIME
+-
+ /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+    significant byte first (like Motorola and SPARC, unlike Intel). */
+ #if defined AC_APPLE_UNIVERSAL_BUILD
+Index: omniORB/include/omniconfig.h.in
+===================================================================
+--- omniORB/include/omniconfig.h.in	(revision 6647)
++++ omniORB/include/omniconfig.h.in	(revision 6648)
+@@ -3,7 +3,7 @@
+  * omniconfig.h.in            Created on: 2002/07/11
+  *                            Author    : Duncan Grisby (dgrisby)
+  *
+- *    Copyright (C) 2002 Duncan Grisby
++ *    Copyright (C) 2002-2023 Duncan Grisby
+  *
+  *    This file is part of the omniORB library
+  *
+@@ -33,8 +33,41 @@
+ 
+ #include <omniORB4/acconfig.h>
+ 
+-#define @PLATFORM_DEFINE@ 1
+-#define @PROCESSOR_DEFINE@ 1
++#if !defined(__linux__)          && \
++    !defined(__cygwin__)         && \
++    !defined(__sunos__)          && \
++    !defined(__osf1__)           && \
++    !defined(__hpux__)           && \
++    !defined(__nextstep__)       && \
++    !defined(__irix__)           && \
++    !defined(__aix__)            && \
++    !defined(__darwin__)         && \
++    !defined(__freebsd__)        && \
++    !defined(__FreeBSD_kernel__) && \
++    !defined(__netbsd__)         && \
++    !defined(__openbsd__)        && \
++    !defined(__osr5__)           && \
++    !defined(__hurd__)           && \
++    !defined(__win32__)
++# define @PLATFORM_DEFINE@ 1
++#endif
++
++#if !defined(__x86__)     && \
++    !defined(__x86_64__)  && \
++    !defined(__sparc__)   && \
++    !defined(__alpha__)   && \
++    !defined(__m68k__)    && \
++    !defined(__mips__)    && \
++    !defined(__arm__)     && \
++    !defined(__arm64__)   && \
++    !defined(__s390__)    && \
++    !defined(__ia64__)    && \
++    !defined(__hppa__)    && \
++    !defined(__powerpc__) && \
++    !defined(__riscv)
++# define @PROCESSOR_DEFINE@ 1
++#endif
++
+ #define __OSVERSION__ @OSVERSION@
+ 
+ #undef PACKAGE_BUGREPORT
+Index: omniORB/mk/beforeauto.mk.in
+===================================================================
+--- omniORB/mk/beforeauto.mk.in	(revision 6647)
++++ omniORB/mk/beforeauto.mk.in	(revision 6648)
+@@ -34,15 +34,17 @@
+ # Directories for installation
+ #
+ 
+-prefix        	 := @prefix@
+-exec_prefix   	 := @exec_prefix@
+-INSTALLTARGET 	 := 1
+-INSTALLINCDIR 	 := $(DESTDIR)@includedir@
+-INSTALLBINDIR 	 := $(DESTDIR)@bindir@
+-INSTALLLIBDIR 	 := $(DESTDIR)@libdir@
+-INSTALLPYTHONDIR := $(DESTDIR)@pythondir@
+-INSTALLPYEXECDIR := $(DESTDIR)@pyexecdir@
+-INSTALLIDLDIR    := $(DESTDIR)@datadir@/idl
++prefix             := @prefix@
++exec_prefix        := @exec_prefix@
++PYTHON_PREFIX      := @prefix@
++PYTHON_EXEC_PREFIX := @exec_prefix@
++INSTALLTARGET      := 1
++INSTALLINCDIR      := $(DESTDIR)@includedir@
++INSTALLBINDIR      := $(DESTDIR)@bindir@
++INSTALLLIBDIR      := $(DESTDIR)@libdir@
++INSTALLPYTHONDIR   := $(DESTDIR)@pythondir@
++INSTALLPYEXECDIR   := $(DESTDIR)@pyexecdir@
++INSTALLIDLDIR      := $(DESTDIR)@datadir@/idl
+ 
+ 
+ #############################################################################
+Index: omniORB/src/tool/omniidl/cxx/cccp/cccp.c
+===================================================================
+--- omniORB/src/tool/omniidl/cxx/cccp/cccp.c	(revision 6647)
++++ omniORB/src/tool/omniidl/cxx/cccp/cccp.c	(revision 6648)
+@@ -86,15 +86,10 @@
+ #ifndef RLIMIT_STACK
+ # include <time.h>
+ #else
+-# if TIME_WITH_SYS_TIME
++# if HAVE_SYS_TIME_H
+ #  include <sys/time.h>
++# else
+ #  include <time.h>
+-# else
+-#  if HAVE_SYS_TIME_H
+-#   include <sys/time.h>
+-#  else
+-#   include <time.h>
+-#  endif
+ # endif
+ # include <sys/resource.h>
+ #endif
+Index: omniORB/src/tool/omniidl/python/scripts/omniidl.in
+===================================================================
+--- omniORB/src/tool/omniidl/python/scripts/omniidl.in	(revision 6647)
++++ omniORB/src/tool/omniidl/python/scripts/omniidl.in	(revision 6648)
+@@ -4,7 +4,7 @@
+ # omniidl.in                Created on: 1999/10/29
+ #			    Author    : Duncan Grisby (dpg1)
+ #
+-#    Copyright (C) 2014 Apasphere Ltd
++#    Copyright (C) 2014-2023 Apasphere Ltd
+ #    Copyright (C) 1999 AT&T Laboratories Cambridge
+ #
+ #  This file is part of omniidl.
+@@ -28,10 +28,10 @@
+ 
+ import sys
+ 
+-if sys.hexversion < 0x10502f0:
++if sys.hexversion < 0x20700f0:
+     sys.stderr.write("\n\n")
+     sys.stderr.write("omniidl: WARNING!!\n\n")
+-    sys.stderr.write("omniidl: Python version 1.5.2 or later is required.\n")
++    sys.stderr.write("omniidl: Python version 2.7 or later is required.\n")
+     sys.stderr.write("omniidl: " + sys.executable + " is version " + \
+                      sys.version + "\n")
+     sys.stderr.write("omniidl: Execution is likely to fail.\n")
+@@ -44,7 +44,8 @@
+ binarchdir = os.path.abspath(os.path.dirname(sys.argv[0]))
+ 
+ # Try a path based on the installation prefix
+-sppath = "@prefix@/lib/python" + sys.version[:3] + "/site-packages"
++py_version = ".".join(sys.version.split(".")[:2])
++sppath = "@prefix@/lib/python" + py_version + "/site-packages"
+ 
+ if os.path.isdir(sppath):
+     sys.path.append(sppath)
+@@ -56,9 +57,9 @@
+     treedir, bin     = os.path.split(bindir)
+     if bin == "bin":
+         pylibdir    = os.path.join(treedir, "lib", "python")
+-        vpylibdir   = pylibdir + sys.version[:3] + "/site-packages"
++        vpylibdir   = pylibdir + py_version + "/site-packages"
+         vpylib64dir = (os.path.join(treedir, "lib64", "python") +
+-                       sys.version[:3] + "/site-packages")
++                       py_version + "/site-packages")
+         archlibdir  = os.path.join(treedir, "lib", archname)
+ 
+         if os.path.isdir(pylibdir):
+@@ -75,9 +76,9 @@
+ 
+     elif archname == "bin":
+         pylibdir    = os.path.join(bindir, "lib", "python")
+-        vpylibdir   = pylibdir + sys.version[:3] + "/site-packages"
++        vpylibdir   = pylibdir + py_version + "/site-packages"
+         vpylib64dir = (os.path.join(bindir, "lib64", "python") +
+-                       sys.version[:3] + "/site-packages")
++                       py_version + "/site-packages")
+         archlibdir  = os.path.join(bindir, "lib")
+ 
+         if os.path.isdir(pylibdir):
+@@ -93,9 +94,9 @@
+             sys.path.insert(0, archlibdir)
+ 
+ # Last chance, try a path based on the installation prefixes
+-sys.path.append("@prefix@/lib/python" + sys.version[:3] + "/site-packages")
++sys.path.append("@prefix@/lib/python" + py_version + "/site-packages")
+ 
+-paths = [ "@exec_prefix@/lib/python" + sys.version[:3] + "/site-packages",
++paths = [ "@exec_prefix@/lib/python" + py_version + "/site-packages",
+           "@pythondir@",
+           "@pyexecdir@" ]
+ 
+@@ -103,7 +104,9 @@
+ # Autoconf insists on making our life difficult...
+ for path in paths:
+     path = path.replace("${exec_prefix}", "@exec_prefix@")
++    path = path.replace("${PYTHON_EXEC_PREFIX}", "@exec_prefix@")
+     path = path.replace("${prefix}", "@prefix@")
++    path = path.replace("${PYTHON_PREFIX}", "@prefix@")
+     sys.path.append(path)
+ 
+ try:
+Index: omniORB/src/tool/omniidl/python/scripts/omniidlrun.py
+===================================================================
+--- omniORB/src/tool/omniidl/python/scripts/omniidlrun.py	(revision 6647)
++++ omniORB/src/tool/omniidl/python/scripts/omniidlrun.py	(revision 6648)
+@@ -4,6 +4,7 @@
+ # omniidlrun.py             Created on: 1999/10/29
+ #			    Author    : Duncan Grisby (dpg1)
+ #
++#    Copyright (C) 2014-2023 Apasphere Ltd
+ #    Copyright (C) 1999 AT&T Laboratories Cambridge
+ #
+ #  This file is part of omniidl.
+@@ -27,10 +28,10 @@
+ 
+ import sys
+ 
+-if sys.hexversion < 0x10502f0:
++if sys.hexversion < 0x20700f0:
+     sys.stderr.write("\n\n")
+     sys.stderr.write("omniidl: WARNING!!\n\n")
+-    sys.stderr.write("omniidl: Python version 1.5.2 or later is required.\n")
++    sys.stderr.write("omniidl: Python version 2.7 or later is required.\n")
+     sys.stderr.write("omniidl: " + sys.executable + " is version " + \
+                      sys.version + "\n")
+     sys.stderr.write("omniidl: Execution is likely to fail.\n")
+Index: omniORB/src/tool/omniidl/python3/scripts/omniidl.in
+===================================================================
+--- omniORB/src/tool/omniidl/python3/scripts/omniidl.in	(revision 6647)
++++ omniORB/src/tool/omniidl/python3/scripts/omniidl.in	(revision 6648)
+@@ -4,7 +4,7 @@
+ # omniidl.in                Created on: 1999/10/29
+ #			    Author    : Duncan Grisby (dpg1)
+ #
+-#    Copyright (C) 2014 Apasphere Ltd
++#    Copyright (C) 2014-2023 Apasphere Ltd
+ #    Copyright (C) 1999 AT&T Laboratories Cambridge
+ #
+ #  This file is part of omniidl.
+@@ -28,10 +28,10 @@
+ 
+ import sys
+ 
+-if sys.hexversion < 0x10502f0:
++if sys.hexversion < 0x20700f0:
+     sys.stderr.write("\n\n")
+     sys.stderr.write("omniidl: WARNING!!\n\n")
+-    sys.stderr.write("omniidl: Python version 1.5.2 or later is required.\n")
++    sys.stderr.write("omniidl: Python version 2.7 or later is required.\n")
+     sys.stderr.write("omniidl: " + sys.executable + " is version " + \
+                      sys.version + "\n")
+     sys.stderr.write("omniidl: Execution is likely to fail.\n")
+@@ -44,7 +44,8 @@
+ binarchdir = os.path.abspath(os.path.dirname(sys.argv[0]))
+ 
+ # Try a path based on the installation prefix
+-sppath = "@prefix@/lib/python" + sys.version[:3] + "/site-packages"
++py_version = ".".join(sys.version.split(".")[:2])
++sppath = "@prefix@/lib/python" + py_version + "/site-packages"
+ 
+ if os.path.isdir(sppath):
+     sys.path.append(sppath)
+@@ -56,9 +57,9 @@
+     treedir, bin     = os.path.split(bindir)
+     if bin == "bin":
+         pylibdir    = os.path.join(treedir, "lib", "python")
+-        vpylibdir   = pylibdir + sys.version[:3] + "/site-packages"
++        vpylibdir   = pylibdir + py_version + "/site-packages"
+         vpylib64dir = (os.path.join(treedir, "lib64", "python") +
+-                       sys.version[:3] + "/site-packages")
++                       py_version + "/site-packages")
+         archlibdir  = os.path.join(treedir, "lib", archname)
+ 
+         if os.path.isdir(pylibdir):
+@@ -75,9 +76,9 @@
+ 
+     elif archname == "bin":
+         pylibdir    = os.path.join(bindir, "lib", "python")
+-        vpylibdir   = pylibdir + sys.version[:3] + "/site-packages"
++        vpylibdir   = pylibdir + py_version + "/site-packages"
+         vpylib64dir = (os.path.join(bindir, "lib64", "python") +
+-                       sys.version[:3] + "/site-packages")
++                       py_version + "/site-packages")
+         archlibdir  = os.path.join(bindir, "lib")
+ 
+         if os.path.isdir(pylibdir):
+@@ -93,9 +94,9 @@
+             sys.path.insert(0, archlibdir)
+ 
+ # Last chance, try a path based on the installation prefixes
+-sys.path.append("@prefix@/lib/python" + sys.version[:3] + "/site-packages")
++sys.path.append("@prefix@/lib/python" + py_version + "/site-packages")
+ 
+-paths = [ "@exec_prefix@/lib/python" + sys.version[:3] + "/site-packages",
++paths = [ "@exec_prefix@/lib/python" + py_version + "/site-packages",
+           "@pythondir@",
+           "@pyexecdir@" ]
+ 
+@@ -103,7 +104,9 @@
+ # Autoconf insists on making our life difficult...
+ for path in paths:
+     path = path.replace("${exec_prefix}", "@exec_prefix@")
++    path = path.replace("${PYTHON_EXEC_PREFIX}", "@exec_prefix@")
+     path = path.replace("${prefix}", "@prefix@")
++    path = path.replace("${PYTHON_PREFIX}", "@prefix@")
+     sys.path.append(path)
+ 
+ try:
+Index: omniORB/src/tool/omniidl/python3/scripts/omniidlrun.py
+===================================================================
+--- omniORB/src/tool/omniidl/python3/scripts/omniidlrun.py	(revision 6647)
++++ omniORB/src/tool/omniidl/python3/scripts/omniidlrun.py	(revision 6648)
+@@ -4,6 +4,7 @@
+ # omniidlrun.py             Created on: 1999/10/29
+ #			    Author    : Duncan Grisby (dpg1)
+ #
++#    Copyright (C) 2014-2023 Apasphere Ltd
+ #    Copyright (C) 1999 AT&T Laboratories Cambridge
+ #
+ #  This file is part of omniidl.
+@@ -27,10 +28,10 @@
+ 
+ import sys
+ 
+-if sys.hexversion < 0x10502f0:
++if sys.hexversion < 0x20700f0:
+     sys.stderr.write("\n\n")
+     sys.stderr.write("omniidl: WARNING!!\n\n")
+-    sys.stderr.write("omniidl: Python version 1.5.2 or later is required.\n")
++    sys.stderr.write("omniidl: Python version 2.7 or later is required.\n")
+     sys.stderr.write("omniidl: " + sys.executable + " is version " + \
+                      sys.version + "\n")
+     sys.stderr.write("omniidl: Execution is likely to fail.\n")

--- a/recipe/omniorb-r6651.patch
+++ b/recipe/omniorb-r6651.patch
@@ -1,0 +1,10 @@
+Index: omniORB/contrib/pkgconfig/omnithread3.pc.in
+===================================================================
+--- omniORB/contrib/pkgconfig/omnithread3.pc.in	(revision 6650)
++++ omniORB/contrib/pkgconfig/omnithread3.pc.in	(revision 6651)
+@@ -8,4 +8,4 @@
+ Version: @PACKAGE_VERSION@
+ Requires:
+ Libs: -L${libdir} -lomnithread
+-Cflags: -D@PROCESSOR_DEFINE@ -D@PLATFORM_DEFINE@ -D__OSVERSION__=@OSVERSION@ -I${includedir}
++Cflags: -D__OSVERSION__=@OSVERSION@ -I${includedir}

--- a/recipe/omniorb-r6653.patch
+++ b/recipe/omniorb-r6653.patch
@@ -1,0 +1,180 @@
+Index: omniORB/mk/beforeauto.mk.in
+===================================================================
+--- omniORB/mk/beforeauto.mk.in	(revision 6652)
++++ omniORB/mk/beforeauto.mk.in	(revision 6653)
+@@ -819,7 +819,6 @@
+ 
+ ###################
+ ifdef Linux
+-IMPORT_CPPFLAGS += -D__linux__
+ OMNITHREAD_POSIX_CPPFLAGS = -DNoNanoSleep -DPthreadDraftVersion=10
+ OMNITHREAD_CPPFLAGS = -D_REENTRANT
+ OMNITHREAD_LIB += -lpthread
+@@ -841,7 +840,6 @@
+ 
+ ###################
+ ifdef SunOS
+-IMPORT_CPPFLAGS += -D__sunos__
+ OMNITHREAD_POSIX_CPPFLAGS = -DPthreadDraftVersion=10
+ OMNITHREAD_CPPFLAGS = -DUsePthread -D_REENTRANT $(CXXMTFLAG)
+ SOCKET_LIB = -lsocket -lnsl
+@@ -872,8 +870,6 @@
+ 
+ ###################
+ ifdef OSF1
+-IMPORT_CPPFLAGS          += -D__osf1__
+-
+ ifeq (@OSVERSION@,3)
+ OMNITHREAD_POSIX_CPPFLAGS = -DPthreadDraftVersion=4 -DNoNanoSleep
+ else
+@@ -919,7 +915,6 @@
+ 
+ ###################
+ ifdef HPUX
+-IMPORT_CPPFLAGS += -D__hpux__
+ INSTLIBFLAGS     = -m 0755
+ 
+ ifeq (@OSVERSION@,10)
+@@ -980,7 +975,6 @@
+ 
+ ###################
+ ifdef NextStep
+-IMPORT_CPPFLAGS += -D__nextstep__
+ 
+ ThreadSystem = Mach
+ OMNITHREAD_CPPFLAGS = -D_REENTRANT
+@@ -992,8 +986,6 @@
+ 
+ ###################
+ ifdef IRIX
+-IMPORT_CPPFLAGS += -D__irix__
+-
+ OMNITHREAD_POSIX_CPPFLAGS = -DPthreadDraftVersion=10 \
+ 			    -DPthreadSupportThreadPriority
+ OMNITHREAD_LIB += -lpthread
+@@ -1016,8 +1008,6 @@
+ ifdef AIX
+ ifndef Compiler_GCC		# Assuming XlC compiler
+ 
+-IMPORT_CPPFLAGS += -D__aix__
+-
+ CMAKEDEPEND     += -D_AIX
+ CXXMAKEDEPEND   += -D_AIX
+ CDEBUGFLAGS      =
+@@ -1043,7 +1033,6 @@
+ 
+ ifdef Compiler_GCC
+ 
+-IMPORT_CPPFLAGS += -D__aix__
+ CMAKEDEPEND     += -D_AIX
+ CXXMAKEDEPEND   += -D_AIX
+ CXXLINKOPTIONS  += -Wl,-brtl -Wl,-blibpath:/lib:/usr/lib:$(prefix)/lib
+@@ -1083,8 +1072,6 @@
+ 
+ ###################
+ ifdef Darwin
+-IMPORT_CPPFLAGS += -D__darwin__
+-
+ OMNITHREAD_POSIX_CPPFLAGS = -DPthreadDraftVersion=10 \
+                             -DPthreadSupportThreadPriority -DNoNanoSleep
+ 
+@@ -1123,8 +1110,6 @@
+ 
+ ###################
+ ifdef FreeBSD
+-IMPORT_CPPFLAGS += -D__freebsd__
+-
+ OMNITHREAD_CPPFLAGS = -D_REENTRANT -D_THREAD_SAFE
+ OMNITHREAD_POSIX_CPPFLAGS = -DUsePthread -DPthreadDraftVersion=10
+ OMNITHREAD_LIB += -pthread
+@@ -1132,8 +1117,6 @@
+ 
+ ###################
+ ifdef NetBSD
+-IMPORT_CPPFLAGS += -D__netbsd__
+-
+ OMNITHREAD_CPPFLAGS = -D_REENTRANT
+ OMNITHREAD_POSIX_CPPFLAGS = -DUsePthread -DPthreadDraftVersion=10
+ OMNITHREAD_LIB += -pthread
+@@ -1141,8 +1124,6 @@
+ 
+ ###################
+ ifdef OpenBSD
+-IMPORT_CPPFLAGS += -D__openbsd__
+-
+ OMNITHREAD_CPPFLAGS = -D_REENTRANT -D_THREAD_SAFE
+ OMNITHREAD_POSIX_CPPFLAGS = -DUsePthread -DPthreadDraftVersion=10
+ OMNITHREAD_LIB += -pthread
+@@ -1150,8 +1131,6 @@
+ 
+ ###################
+ ifdef OSR5
+-IMPORT_CPPFLAGS += -D__osr5__
+-
+ COPTIONS = -fpcc-struct-return
+ 
+ OMNITHREAD_POSIX_CPPFLAGS = -DPthreadDraftVersion=6 \
+@@ -1162,7 +1141,6 @@
+ ifdef Cygwin
+ MKDIRHIER = mkdir -p
+ CXXLINKOPTIONS += -Wl,--enable-auto-import
+-IMPORT_CPPFLAGS += -D__cygwin__
+ SHAREDLIB_CPPFLAGS =
+ OMNITHREAD_POSIX_CPPFLAGS = -DNoNanoSleep -DPthreadDraftVersion=10
+ OMNITHREAD_CPPFLAGS = -D_REENTRANT
+@@ -1221,56 +1199,6 @@
+ 
+ ###########################################################################
+ #
+-# Processor
+-#
+-
+-ifdef x86Processor
+-IMPORT_CPPFLAGS += -D__x86__
+-endif
+-
+-ifdef x8664Processor
+-IMPORT_CPPFLAGS += -D__x86_64__
+-endif
+-
+-ifdef SparcProcessor
+-IMPORT_CPPFLAGS += -D__sparc__
+-endif
+-
+-ifdef AlphaProcessor
+-IMPORT_CPPFLAGS += -D__alpha__
+-endif
+-
+-ifdef m68kProcessor
+-IMPORT_CPPFLAGS += -D__m68k__
+-endif
+-
+-ifdef IndigoProcessor
+-IMPORT_CPPFLAGS += -D__mips__
+-endif
+-
+-ifdef ArmProcessor
+-IMPORT_CPPFLAGS += -D__arm__
+-endif
+-
+-ifdef s390Processor
+-IMPORT_CPPFLAGS += -D__s390__
+-endif
+-
+-ifdef ia64Processor
+-IMPORT_CPPFLAGS += -D__ia64__
+-endif
+-
+-ifdef HppaProcessor
+-IMPORT_CPPFLAGS += -D__hppa__
+-endif
+-
+-ifdef PowerPCProcessor
+-IMPORT_CPPFLAGS += -D__powerpc__
+-endif
+-
+-
+-###########################################################################
+-#
+ # Final things
+ #

--- a/recipe/patch-configure.diff
+++ b/recipe/patch-configure.diff
@@ -1,20 +1,22 @@
---- configure	2018-12-11 00:37:21.000000000 +0100
-+++ configure	2019-02-25 09:22:49.956970400 +0100
-@@ -4361,7 +4361,7 @@
-     sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
+diff --git a/configure b/configure
+index ee2bcd9..2df5139 100755
+--- a/configure
++++ b/configure
+@@ -5384,7 +5384,7 @@ if can_use_sysconfig:
+   sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
  else:
-     from distutils import sysconfig
--    sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
-+    sitedir = sysconfig.get_python_lib()
+   from distutils import sysconfig
+-  sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
++  sitedir = sysconfig.get_python_lib()
  sys.stdout.write(sitedir)"`
-      case $am_cv_python_pythondir in
-      $am_py_prefix*)
-@@ -4405,7 +4405,7 @@
-     sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_prefix'})
+    #
+    case $am_cv_python_pythondir in
+@@ -5427,7 +5427,7 @@ if can_use_sysconfig:
+   sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_exec_prefix'})
  else:
-     from distutils import sysconfig
--    sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_prefix')
-+    sitedir = sysconfig.get_python_lib()
+   from distutils import sysconfig
+-  sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_exec_prefix')
++  sitedir = sysconfig.get_python_lib()
  sys.stdout.write(sitedir)"`
-      case $am_cv_python_pyexecdir in
-      $am_py_exec_prefix*)
+    #
+    case $am_cv_python_pyexecdir in


### PR DESCRIPTION
- r6653: Remove unnecessary platform and processor defines.
- r6651: Remove processor and platform defines from .pc file.
- r6648: Avoid setting possibly-incorrect processor define (__arm__ instead of __arm64__). Update autoconf and Python version support.
- r6639: Apple compiler does not define __VFP_FP__ on ARM, but the CPU uses VFP floating point format.

Update patch-configure.diff as configure is impacted by the above patches

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
