### PR TITLE
also add correct run-export to omniorb itself

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,9 @@ source:
     - patch-configure.diff                                 # [unix]
 
 build:
-  number: 1
+  number: 2
+  run_exports:
+    - {{ pin_subpackage('omniorb-libs', max_pin='x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
The lack of this is causing wrong metadata for omniorbpy, see e.g. https://github.com/conda-forge/gepetto-viewer-corba-feedstock/pull/18

Also, this package should not use the same name for an output and the feedstock itself. In this case it looks correct, but it's quite fragile to get right (e.g. tests under the `omniorb` output will not be run).