### PR TITLE
Apply patch to fix macOS compatibility version

### DIFF
--- a/recipe/fix-macos-compatibility-version.patch
+++ b/recipe/fix-macos-compatibility-version.patch
@@ -1,0 +1,34 @@
+diff --git a/mk/beforeauto.mk.in b/mk/beforeauto.mk.in
+index 9b6251e..1d9ed48 100644
+--- a/mk/beforeauto.mk.in
++++ b/mk/beforeauto.mk.in
+@@ -1123,7 +1123,9 @@ SharedLibraryFullNameTemplate = lib$$1$$2.$$3.$$4.$(SHAREDLIB_SUFFIX)
+ SharedLibrarySoNameTemplate = lib$$1$$2.$$3.$(SHAREDLIB_SUFFIX)
+ SharedLibraryLibNameTemplate = lib$$1$$2.$(SHAREDLIB_SUFFIX)
+ SharedLibraryPlatformLinkFlagsTemplate = -dynamiclib $(CXXLINKOPTIONS) \
+-                                         -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate)
++                                         -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate) \
++                                         -compatibility_version $$2.$$3 \
++                                         -current_version $$2.$$3.$$4
+ PythonLibraryPlatformLinkFlagsTemplate = -bundle -undefined dynamic_lookup
+ PythonSHAREDLIB_SUFFIX = so
+ 
+diff --git a/src/lib/omnithread/dir.mk b/src/lib/omnithread/dir.mk
+index 14adb61..97fbacd 100644
+--- a/src/lib/omnithread/dir.mk
++++ b/src/lib/omnithread/dir.mk
+@@ -108,6 +108,14 @@ else
+   imps := $(LIB_IMPORTS)
+ endif
+ 
++ifdef Darwin
++# Override normal compatibility for the version with only two components.
++SharedLibraryPlatformLinkFlagsTemplate = -dynamiclib $(CXXLINKOPTIONS) \
++                                         -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate) \
++                                         -compatibility_version $$3.$$4 \
++                                         -current_version $$3.$$4
++endif
++
+ mkshared::
+ 	@(dir=shared; $(CreateDir))
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
     - 0001-Avoid-kernel-128-character-shebang-limit.patch  # [unix]
     - windows-build.patch                                  # [win]
     - patch-configure.diff                                 # [unix]
+    - fix-macos-compatibility-version.patch                # [osx]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('omniorb-libs', max_pin='x.x') }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

omniorb didn't pass the `-compatibility_version` flag at build time.
This made the `max_pin=x.x` incorrect on macOS. See https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/636

This has been reported and fixed upstream. Apply patch taken from https://sourceforge.net/p/omniorb/svn/6692/ and https://sourceforge.net/p/omniorb/svn/6693/
