### PR TITLE
Fix macos install name

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,15 +9,17 @@ source:
     sha256: accd25e2cb70c4e33ed227b0d93e9669e38c46019637887c771398870ed45e7a
     patches:
       - 0001-Avoid-kernel-128-character-shebang-limit.patch  # [unix]
+      - omniorb-r6785.patch
       - windows-build.patch                                  # [win]
   - url: https://sourceforge.net/projects/omniorb/files/omniORBpy/omniORBpy-{{ version }}/omniORBpy-{{ version }}.tar.bz2
     sha256: 385c14e7ccd8463a68a388f4f2be3edcdd3f25a86b839575326bd2dc00078c22
     patches:
+      - omniorbpy-r6785.patch
       - windows-build-omniorbpy.patch                        # [win]
     folder: src/lib/omniORBpy
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/omniorb-r6785.patch
+++ b/recipe/omniorb-r6785.patch
@@ -1,0 +1,26 @@
+Index: mk/beforeauto.mk.in
+===================================================================
+--- mk/beforeauto.mk.in	(revision 6784)
++++ mk/beforeauto.mk.in	(revision 6785)
+@@ -1123,7 +1123,7 @@
+ SharedLibrarySoNameTemplate = lib$$1$$2.$$3.$(SHAREDLIB_SUFFIX)
+ SharedLibraryLibNameTemplate = lib$$1$$2.$(SHAREDLIB_SUFFIX)
+ SharedLibraryPlatformLinkFlagsTemplate = -dynamiclib $(CXXLINKOPTIONS) \
+-                                         -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate) \
++                                         -install_name $(INSTALLLIBDIR)/$(SharedLibrarySoNameTemplate) \
+                                          -compatibility_version $$2.$$3 \
+                                          -current_version $$2.$$3.$$4
+ PythonLibraryPlatformLinkFlagsTemplate = -bundle -undefined dynamic_lookup
+Index: src/lib/omnithread/dir.mk
+===================================================================
+--- src/lib/omnithread/dir.mk	(revision 6784)
++++ src/lib/omnithread/dir.mk	(revision 6785)
+@@ -111,7 +111,7 @@
+ ifdef Darwin
+ # Override normal compatibility for the version with only two components.
+ SharedLibraryPlatformLinkFlagsTemplate = -dynamiclib $(CXXLINKOPTIONS) \
+-                                         -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate) \
++                                         -install_name $(INSTALLLIBDIR)/$(SharedLibrarySoNameTemplate) \
+                                          -compatibility_version $$3.$$4 \
+                                          -current_version $$3.$$4
+ endif

--- a/recipe/omniorbpy-r6785.patch
+++ b/recipe/omniorbpy-r6785.patch
@@ -1,0 +1,13 @@
+Index: mk/beforeauto.mk.in
+===================================================================
+--- mk/beforeauto.mk.in	(revision 6784)
++++ mk/beforeauto.mk.in	(revision 6785)
+@@ -1098,7 +1098,7 @@
+ SharedLibrarySoNameTemplate = lib$$1$$2.$$3.$(SHAREDLIB_SUFFIX)
+ SharedLibraryLibNameTemplate = lib$$1$$2.$(SHAREDLIB_SUFFIX)
+ SharedLibraryPlatformLinkFlagsTemplate = -dynamiclib \
+-                                         -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate)
++                                         -install_name $(INSTALLLIBDIR)/$(SharedLibrarySoNameTemplate)
+ PythonLibraryPlatformLinkFlagsTemplate = -bundle -undefined dynamic_lookup
+ PythonSHAREDLIB_SUFFIX = so
+ 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

On macOS, the `install_name` was always set to the full version, which means it didn't match the `run_exports`:

```
$ otool -D  libomniORB4.dylib
libomniORB4.dylib:
@rpath/libomniORB4.3.3.dylib
```

When compiling cpptango against omniorb 4.3.2, it would link against `@rpath/libomniORB4.3.2.dylib`, meaning you can't run it with 4.3.3.

With this change the install_name is now `@rpath/libomniORB4.3.dylib`.

See https://www.omniorb-support.com/pipermail/omniorb-list/2025-May/032334.html

Fix https://github.com/conda-forge/cpptango-feedstock/issues/55

