### PR TITLE
Try to enable pkg-config for windows builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - autoconf    # [unix]
-    - pkg-config  # [unix]
+    - pkg-config
     - make
     - m2-base       # [win]
     - m2-diffutils  # [win]
@@ -58,7 +58,7 @@ outputs:
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - pkg-config  # [unix]
+        - pkg-config
         - make
       host:
         - openssl
@@ -85,6 +85,7 @@ outputs:
         - if not exist %LIBRARY_LIB%\\COS4_rt.lib exit 1                   # [win]
         - if not exist %LIBRARY_LIB%\\omnisslTP4_rt.lib exit 1             # [win]
         - if not exist %LIBRARY_LIB%\\omnithread_rt.lib exit 1             # [win]
+        - if not exist %LIBRARY_LIB%\\pkgconfig\\omniORB4.pc exit 1        # [win]
 
   - name: omniorb
     script: install_omniorb.sh  # [unix]
@@ -100,7 +101,7 @@ outputs:
         - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - pkg-config  # [unix]
+        - pkg-config
         - make
       host:
         - python
@@ -141,7 +142,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - autoconf   # [unix]
-        - pkg-config  # [unix]
+        - pkg-config
         - make
         - m2-base       # [win]
         - m2-diffutils  # [win]


### PR DESCRIPTION
I'm trying to build a tango-rs package, and it currently fails on Windows, as omniORB4.pc is missing. I sadly could not manage to build locally, so I'm trying to see if this builds in CI.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
